### PR TITLE
Setup Github Actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,23 @@
+name: Check changelog
+
+on:
+  push:
+    branches: [ master, ci ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build_and_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout mkchlog
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Checkout toolchain
+        # https://github.com/dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build mkchlog
+        run: cargo build
+      - name: Check our own changelog
+        run: target/debug/mkchlog -c bc58e6bf2cf640d46aa832e297d0f215f76dfce0 check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on:
+  push:
+    branches: [ master, ci ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout mkchlog
+        uses: actions/checkout@v2
+      - name: Checkout toolchain
+        # https://github.com/dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Test mkchlog
+        run: cargo test

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,7 +6,7 @@ use mkchlog::template::Template;
 use mocks::GitCmdMock;
 use std::fs::File;
 
-const YAML_FILE: &str = ".mkchlog.yml";
+const YAML_FILE: &str = "tests/mkchlog.yml";
 
 #[test]
 fn it_produces_correct_output() {

--- a/tests/mkchlog.yml
+++ b/tests/mkchlog.yml
@@ -12,12 +12,5 @@ sections:
                 title: Fixed vulnerabilities
     features:
         title: New features
-    bug_fixes:
-        title: Fixed bugs
-    breaking:
-        title: Breaking changes
     perf:
         title: Performance improvements
-    dev:
-        title: Development
-        description: Internal development changes


### PR DESCRIPTION
This configures github actions to build `mkchlog` as well as run it on its own repository. Also added a few more sections to `.mkchlog.yml` so we're more flexible in the future, including a section used in this commit. :)