### PR TITLE
Use imperative mood in commit subject examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sections:
         description: This section contains very important security-related changes.
         subsections:
             vuln_fixes:
-                title: Fixed vulnerabilities
+                title: Fix vulnerabilities
     features:
         title: New features
     perf:
@@ -56,7 +56,7 @@ sections:
 #### Commits
 
 ```
-Added ability to skip commits.
+Add ability to skip commits
 
 This allows commits to be skipped by typing changelog: skip
 at the end of the commit. This is mainly useful for typo
@@ -68,7 +68,7 @@ changelog:
 ```
 
 ```
-Fixed grammar mistakes.
+Fix grammar mistakes
 
 We found 42 grammar mistakes that are fixed in this commit.
 
@@ -83,12 +83,12 @@ Avoiding allocations like this introduces 10% speedup.
 
 changelog:
     section: perf
-    title: Improved processing speed by 10%
+    title: Improve processing speed by 10%
     title-is-enough: true
 ```
 
 ```
-Fixed TOCTOU race condition when opening file
+Fix TOCTOU race condition when opening file
 
 Previously we checked the file permissions before opening
 the file now we check the metadata using file descriptor
@@ -96,7 +96,7 @@ after opening the file. (before reading)
 
 changelog:
     section: security:vuln_fixes
-    title: Fixed vulnerability related to opening files
+    title: Fix vulnerability related to opening files
     description: The application was vulnerable to attacks
                  if the attacker had access to the working
                  directory. If you run this in such
@@ -112,9 +112,9 @@ changelog:
 
 This section contains very important security-related changes.
 
-### Fixed vulnerabilities
+### Fix vulnerabilities
 
-#### Fixed vulnerability related to opening files
+#### Fix vulnerability related to opening files
 
 The application was vulnerable to attacks if the attacker had access to the working directory.
 If you run this in such enviroment you should update ASAP.
@@ -122,7 +122,7 @@ If your working directory is **not** accessible by unprivileged users you don't 
 
 ## New features
 
-### Added ability to skip commits.
+### Add ability to skip commits
 
 This allows commits to be skipped by typing changelog: skip
 at the end of the commit. This is mainly useful for typo
@@ -130,7 +130,7 @@ fixes or other things irrelevant to the user of a project.
 
 ## Performance improvements
 
-* Improved processing speed by 10%
+* Improve processing speed by 10%
 ```
 
 ### Explanation


### PR DESCRIPTION
Typically we use imperative mood in commit subject lines, we should do so here in the examples.

Use imperative mood and also remove full stops from the git commit subject line examples.