### PR TITLE
Add option to skip merge commits

### DIFF
--- a/.mkchlog.yml
+++ b/.mkchlog.yml
@@ -1,4 +1,4 @@
-# Possibly general settings here, probably none in the initial version
+skip-merge-commits: true
 
 sections:
     # section identifier selected by project maintainer

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -27,10 +27,12 @@ impl Changelog {
         let commits = self.git.commits()?;
 
         // insert changelog entries from commits to changelog_map
-        for commit in commits {
+        for commit in commits.into_iter().filter(|commit| !self.template.skip_merge_commits || !commit.is_merge()) {
             let mut changes = String::new();
 
-            let commit_changelog_data = CommitChangelogData::new(&commit.changelog_message);
+            let changelog = &commit.changelog_message.as_ref()
+                .ok_or_else(|| format!("Missing 'changelog:' key in commit:\n>>> {}", commit.raw_data))?;
+            let commit_changelog_data = CommitChangelogData::new(changelog);
 
             let changelog_lines = commit_changelog_data.changelog_lines();
             if changelog_lines.len() == 1 && changelog_lines[0] == "skip" {

--- a/src/template.rs
+++ b/src/template.rs
@@ -6,6 +6,7 @@ use std::io::Read;
 /// Template represents parsed YAML config file
 #[derive(Debug)]
 pub struct Template {
+    pub skip_merge_commits: bool,
     changelog_map: ChangelogMap,
 }
 
@@ -24,6 +25,7 @@ impl Template {
         };
 
         let mut template = Self {
+            skip_merge_commits: false,
             changelog_map: ChangelogMap::new(),
         };
         template.parse_config(config)?;
@@ -39,6 +41,12 @@ impl Template {
             Some(v) => v,
             None => return Err("Missing 'sections' key in config file".into()),
         };
+
+        self.skip_merge_commits = yaml
+            .get("skip-merge-commits")
+            .map(|value| value.as_bool().ok_or("Invalid value in skip-merge-commits"))
+            .transpose()?
+            .unwrap_or(false);
 
         let tmpl_sections = tmpl_sections_key
             .as_mapping()


### PR DESCRIPTION
Projects that don't use linear history may have merge commits without `changelog:` in them. This is usually fine, so this change adds an option to skip them.

Note: this still has a problem that it doesn't show some commits. I have to run now so can't investigate. If you find it in the meantime please LMK.