### PR TITLE
Support multi-project repositories

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,6 +1,13 @@
 #!/bin/sh
-if ! cat "$1" | grep -v '^#' | cargo run -- --from-stdin check ; then
+COMMIT_MSG_FILE=$1
+
+FAKE_COMMIT_MESSAGE="$(cat "$COMMIT_MSG_FILE" | grep -v '^#')"
+
+MODIFIED_FILES=$(git diff-index --cached --name-only HEAD)
+
+FAKE_COMMIT_MESSAGE="${FAKE_COMMIT_MESSAGE}\n\n${MODIFIED_FILES}"
+
+if ! echo "$FAKE_COMMIT_MESSAGE" | cargo run -- --from-stdin check ; then
   >&2 echo "Please follow mkchlog rules"
   exit 1
 fi
-

--- a/.githooks/commit_template.txt
+++ b/.githooks/commit_template.txt
@@ -1,6 +1,5 @@
 #
-# Uncomment 'changelog:' part and at least fill in correct 'section'
-# from the provided list of valid sections above.
+# Fill in correct 'section' from the provided list of valid sections above.
 #
 # First line of the commit message serves as a title in the changelog
 # and thus should be very short.
@@ -9,7 +8,7 @@
 # feel free to be detailed.
 #
 # If you do not want to include your commit message into the changelog,
-# you can use 'changelog: skip' and let rest of the changelog lines commented out.
+# simply use 'changelog: skip' and remove the rest of the changelog: part.
 #
 # For more information how to use the tool, see README.md
 #

--- a/.githooks/commit_template.txt
+++ b/.githooks/commit_template.txt
@@ -1,0 +1,14 @@
+#
+# Uncomment 'changelog:' part and at least fill in correct 'section'
+# from the provided list of valid sections above.
+#
+# First line of the commit message serves as a title in the changelog
+# and thus should be very short.
+#
+# Next can be multi-line description of commit, feel free to be detailed.
+#
+# If you do not want to include your commit message into the changelog,
+# you can use 'changelog: skip' and let rest of the changelog lines commented out.
+#
+# For more information how to use the tool, see README.md
+#

--- a/.githooks/commit_template.txt
+++ b/.githooks/commit_template.txt
@@ -5,7 +5,8 @@
 # First line of the commit message serves as a title in the changelog
 # and thus should be very short.
 #
-# Next can be multi-line description of commit, feel free to be detailed.
+# After an empty line you can add multi-line description of commit,
+# feel free to be detailed.
 #
 # If you do not want to include your commit message into the changelog,
 # you can use 'changelog: skip' and let rest of the changelog lines commented out.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --type=bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+exec git diff-index --check --cached $against -- || exit 1
+
+# Check that code lints cleanly.
+cargo clippy --all-features -- -D warnings || exit 1
+
+# Check that there are no formatting issues.
+cargo fmt --check || exit 1

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+
+MODIFIED_FILES=$(git diff-index --cached --name-only HEAD)
+
+if ! COMMIT_TEMPLATE=$(echo "$MODIFIED_FILES" | cargo run -- commit-template) ; then
+  >&2 echo "Please follow mkchlog rules"
+  exit 1
+fi
+
+echo "$(echo "$COMMIT_TEMPLATE" | cat - "$COMMIT_MSG_FILE")" > "$COMMIT_MSG_FILE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ repository = "https://github.com/crywolf/mkchlog"
 clap = { version = "4.0.32", features = ["derive"] }
 indexmap = { version = ">= 1.5.2, < 3.0.0" }
 regex = "1.7.1"
-serde_yaml = ">= 0.8.26, < 0.10.0"
+serde_yaml = { version = ">= 0.8.26, < 0.10.0" }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ You can provide additional options:
 * Commit number to start. This one and previous commits will be skipped. By default, all commit messages are checked. (This option can be also specified in `.mkchlog.yml`.)
 * Config (template) file name [default value is `.mkchlog.yml`]
 * Path to the git repository [default value is the current directory]. (This option can be also specified in `.mkchlog.yml`.)
-* `--from-stdin` Read commit(s) from stdin. Useful to use in a commit-msg git hook.
 
 `mkchlog -c 7c85bee4303d56bededdfacf8fbb7bdc68e2195b -f .mkchlog.yml -g ../git-mkchlog-test/ gen`
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ To use locally configured githooks for the development you can run in the root d
 
 Alternatively add symlinks in your .git/hooks directory to any of the provided githooks.
 
+To use prepared commit message template use the following command:
+
+`git config --local commit.template .githooks/commit_template.txt`
+
 ## Explanation
 
 (Rationale, idea and motivation by [Kixunil](https://github.com/Kixunil))

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ projects:
     default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME [optional]
 ```
 
-If projects list is provided then git commit must contain `project: x` in the changelog message where `x` is one of the specified project names. After a project name the list of directories the project is contained in must be provided. Project `main` in the example above is the "root" project that contains all files in the project root directory plus other directories that do not belong to other projects.
+If projects list is provided then git commit must contain `project: x` in the changelog message where `x` is one of the specified project names. After a project name, the list of directories the project is contained in, must be provided. Project `main` in the example above is the "root" project that contains all files in the project root directory, plus other directories that do not belong to other projects.
 
 To help with migration additional `since-commit` and `default` keywords can be used together. If they are specified then commits up to `since-commit` are considered belonging to `default` project.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mkchlog
 
-Changelog generator tool suitable for user-facing changelogs and based on experiences of existing projects.
+Changelog generator tool suitable for user-facing changelogs and based on experiences of existing projects. More info on rationale is provided in the **Explanation** section below.
 
 ## Overview
 
@@ -36,7 +36,7 @@ Run `mkchlog help` for complete command options.
 #### Config file
 
 ```yaml
-# mkchlog.yml
+# .mkchlog.yml
 # OPTIONAL Commit number to start (same as -c 7c85bee4303d56bededdfacf8fbb7bdc68e2195b)
 skip-commits-up-to: 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 
@@ -179,17 +179,21 @@ Some repositories host multiple projects that are related but should have disjoi
 #### Config file
 
 ```yaml
-# mkchlog.yml
+# .mkchlog.yml
 # top level
 projects:
-    names: [mkchlog, mkchlog-action] # mandatory list of project names [mandatory]
+    list:  # list of allowed projects
+    - main: [".", .github, .githooks] # name: [directory1, directory2, ...]
+    - mkchlog: [mkchlog] # name: [directory]
+    - mkchlog-action: [mkchlog-action] # name: [directory]
+
     since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER [optional]
     default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME [optional]
 ```
 
-If projects `names` list is provided then git commit must contain `project: x` where `x` is one of the specified project names.
+If projects list is provided then git commit must contain `project: x` in the changelog message where `x` is one of the specified project names. After a project name the list of directories the project is contained in must be provided. Project `main` in the example above is the "root" project that contains all files in the project root directory plus other directories that do not belong to other projects.
 
-To help with migration additional `since-commit` and `default` keywords can be used together. if they are specified then commits up to `since-commit` are considered belonging to `default` project.
+To help with migration additional `since-commit` and `default` keywords can be used together. If they are specified then commits up to `since-commit` are considered belonging to `default` project.
 
 #### Commits
 
@@ -211,6 +215,14 @@ To generate changelog for the `mkchlog-action` project use the following command
 `mkchlog --project mkchlog-action gen`
 
 Run `mkchlog help` for complete command options.
+
+## Git Hooks
+
+To use locally configured githooks for the development you can run in the root directory of the repository:
+
+`git config --local core.hooksPath .githooks/`
+
+Alternatively add symlinks in your .git/hooks directory to any of the provided githooks.
 
 ## Explanation
 

--- a/README.md
+++ b/README.md
@@ -267,3 +267,11 @@ Additionally, we don't want to depend on GitHub so that we can migrate easily if
 
 The minimal supported Rust version is 1.63 - Debian Bookworm.
 This also supports using the crates packaged in Debian - just delete `Cargo.lock` (which contains crates.io shasums of crates - some are slightly different in Debian).
+
+## Support
+
+If you find this tool useful and want to say "thank you" and support further development, you are welcome to send some satoshis to
+
+⚡ `capricorn@getalby.com` (LN adress, NOT an email address!)
+
+Every sat counts! Thank you.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ You can provide additional options:
 * Path to the git repository [default value is the current directory]. (This option can be also specified in `.mkchlog.yml`.)
 * `--from-stdin` Read commit(s) from stdin. Useful to use in a commit-msg git hook.
 
-
 `mkchlog -c 7c85bee4303d56bededdfacf8fbb7bdc68e2195b -f .mkchlog.yml -g ../git-mkchlog-test/ gen`
 
 Run `mkchlog help` for complete command options.
@@ -37,6 +36,7 @@ Run `mkchlog help` for complete command options.
 #### Config file
 
 ```yaml
+# mkchlog.yml
 # OPTIONAL Commit number to start (same as -c 7c85bee4303d56bededdfacf8fbb7bdc68e2195b)
 skip-commits-up-to: 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 
@@ -172,7 +172,47 @@ Internal development changes
 * Setup Github Actions
 ```
 
-### Explanation
+## Multi-project setup
+
+Some repositories host multiple projects that are related but should have disjoint changelogs. This is typical for multi-crate workspacess in Rust.
+
+#### Config file
+
+```yaml
+# mkchlog.yml
+# top level
+projects:
+    names: [mkchlog, mkchlog-action] # mandatory list of project names [mandatory]
+    since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER [optional]
+    default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME [optional]
+```
+
+If projects `names` list is provided then git commit must contain `project: x` where `x` is one of the specified project names.
+
+To help with migration additional `since-commit` and `default` keywords can be used together. if they are specified then commits up to `since-commit` are considered belonging to `default` project.
+
+#### Commits
+
+```
+Publish release version rather than debug
+
+This updates the wasm module to one which was compiled with `--release`.
+
+changelog:
+    project: mkchlog-action
+    section: perf
+    inherit: all
+```
+
+#### Usage
+
+To generate changelog for the `mkchlog-action` project use the following command:
+
+`mkchlog --project mkchlog-action gen`
+
+Run `mkchlog help` for complete command options.
+
+## Explanation
 
 (Rationale, idea and motivation by [Kixunil](https://github.com/Kixunil))
 
@@ -204,6 +244,8 @@ This is based on these experiences:
   CI complaining about missing information prevents forgetting.
 
 Additionally, we don't want to depend on GitHub so that we can migrate easily if needed - thus not pulling information from PRs.
+
+---
 
 ### MSRV
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub struct Config {
     pub commit_id: Option<String>,
     /// Name of the project in multi-project repository for which we want to generate changelog.
     pub project: Option<String>,
-    /// Read commit(s) from stdin
+    /// Read commit from stdin
     pub read_from_stdin: bool,
 }
 
@@ -57,7 +57,7 @@ struct Args {
     #[arg(short, long)]
     git_path: Option<PathBuf>,
 
-    /// Read commit(s) from stdin
+    /// Read commit from stdin (useful for git hook)
     #[arg(long, default_value_t = false)]
     from_stdin: bool,
 
@@ -70,7 +70,10 @@ struct Args {
 pub enum Command {
     /// Verify the structure of commit messages
     Check,
-    /// Process git history and output the changelog in markdown format
+    /// Process and verify git history and print the changelog in markdown format
     #[command(name = "gen")]
     Generate,
+    /// Read commit from stdin and print commit template for git hook
+    #[command(name = "commit-template")]
+    CommitTemplate,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,7 +66,7 @@ struct Args {
 }
 
 /// Application commands
-#[derive(Subcommand)]
+#[derive(Subcommand, PartialEq)]
 pub enum Command {
     /// Verify the structure of commit messages
     Check,

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub git_path: Option<std::path::PathBuf>,
     /// Commit number to start. This one and previous commits will be skipped during processing.
     pub commit_id: Option<String>,
+    /// Name of the project in multi-project repository for which we want to generate changelog.
+    pub project: Option<String>,
     /// Read commit(s) from stdin
     pub read_from_stdin: bool,
 }
@@ -29,6 +31,7 @@ impl Config {
             file_path: args.file_path.unwrap_or(PathBuf::from(".mkchlog.yml")),
             git_path: args.git_path,
             commit_id: args.commit,
+            project: args.project,
             read_from_stdin: args.from_stdin,
         })
     }
@@ -38,6 +41,14 @@ impl Config {
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 struct Args {
+    /// Name of the project in multi-project repository for which we want to generate changelog.
+    #[arg(short, long)]
+    project: Option<String>,
+
+    /// Optional commit number. This one and previous commits will be skipped. By default, all commit messages are checked.
+    #[arg(short, long)]
+    commit: Option<String>,
+
     /// Optional path to the YAML template file [default: ".mkchlog.yml"]
     #[arg(short, long)]
     file_path: Option<PathBuf>,
@@ -45,10 +56,6 @@ struct Args {
     /// Optional path to the git repository (path to the .git directory) [default: "./"]
     #[arg(short, long)]
     git_path: Option<PathBuf>,
-
-    /// Optional commit number. This one and previous commits will be skipped. By default, all commit messages are checked.
-    #[arg(short, long)]
-    commit: Option<String>,
 
     /// Read commit(s) from stdin
     #[arg(long, default_value_t = false)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -71,6 +71,9 @@ Date:   Tue Jun 13 16:25:29 2023 +0200
 
     changelog: skip
 
+README.md
+src/template.rs
+
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -83,7 +86,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features";
+        section: features
+
+src/lib.rs";
 
             Ok(ouput.to_string())
         }

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -23,7 +23,9 @@ impl super::GitLogCommand for GitLogCmd {
             .arg("-C")
             .arg(&self.path)
             .arg("log")
-            .arg("--no-merges");
+            .arg("--no-merges")
+            .arg("--stat")
+            .arg("--name-only");
 
         if self.commit_id.is_some() {
             // add argument: git log 7c85bee4303d56bededdfacf8fbb7bdc68e2195b..HEAD

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,8 @@ pub fn run(config: config::Config) -> Result<(), Box<dyn std::error::Error>> {
         &template.settings.projects_settings.projects,
     ) {
         (None, projects) => {
-            if !projects.is_empty() {
+            if !projects.is_empty() && !config.read_from_stdin {
+                // 'project' arg can be empty when reading from stdin (used in Github hook)
                 return Err(
                     "You need to specify project name. Use command 'help' for more information."
                         .into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ pub fn run(config: config::Config) -> Result<(), Box<dyn std::error::Error>> {
         &template.settings.projects_settings.projects,
     ) {
         (None, projects) => {
-            if !projects.is_empty() && !config.read_from_stdin {
-                // 'project' arg can be empty when reading from stdin (used in Github hook)
+            if !projects.is_empty() && config.command == Command::Generate {
+                // 'project' arg can be empty when we are just checking the commits, not generating a changelog
                 return Err(
                     "You need to specify project name. Use command 'help' for more information."
                         .into(),
@@ -81,12 +81,8 @@ pub fn run(config: config::Config) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let mut changelog = Changelog::new(&mut template, git);
-
-    let output = changelog.generate(config.project)?;
-
-    if let Command::Generate = config.command {
-        println!("{}", output);
-    }
+    let output = changelog.generate(config.project, config.command)?;
+    println!("{}", output);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,12 @@ pub fn run(config: config::Config) -> Result<(), Box<dyn std::error::Error>> {
         (None, None) => std::path::PathBuf::from("./"),
     };
 
+    if config.command == Command::CommitTemplate {
+        let output = template.generate_commit_template(std::io::stdin().lock())?;
+        println!("{}", output);
+        return Ok(());
+    }
+
     match (
         &config.project,
         &template.settings.projects_settings.projects,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,12 @@ use std::process;
 
 fn main() {
     let config = Config::new().unwrap_or_else(|err| {
-        eprintln!("{}", err);
+        eprintln!("Error: {}", err);
         process::exit(1);
     });
 
     if let Err(err) = mkchlog::run(config) {
-        eprintln!("{}", err);
+        eprintln!("Error: {}", err);
         process::exit(1);
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -188,6 +188,7 @@ impl<T: Default> Template<T> {
             }
         }
 
+        out.push_str("#\n");
         out.push_str("#changelog:\n");
         if !project.is_empty() {
             out.push_str("#    project: ");
@@ -701,6 +702,7 @@ commit.txt",
         let output = template.generate_commit_template(stdio).unwrap();
 
         let exp_output = "\
+#
 #changelog:
 #    project: main
 #    section:
@@ -812,6 +814,7 @@ src/config.rs",
         let output = template.generate_commit_template(stdio).unwrap();
 
         let exp_output = "\
+#
 #changelog:
 #    section:
 #    inherit: all

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,5 @@
+//! Integration tests without multi-project settings
+
 mod mocks;
 
 use mkchlog::changelog;
@@ -8,6 +10,7 @@ use mocks::GitCmdMock;
 use std::fs::File;
 
 const YAML_FILE: &str = "tests/mkchlog.yml";
+const PROJECT: Option<String> = None;
 
 #[test]
 fn it_produces_correct_output() {
@@ -141,7 +144,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate().unwrap();
+    let output = changelog.generate(PROJECT).unwrap();
 
     let exp_output = "\
 ============================================
@@ -222,7 +225,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate().unwrap();
+    let output = changelog.generate(PROJECT).unwrap();
 
     let exp_output = "\
 ============================================
@@ -302,7 +305,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate().unwrap();
+    let output = changelog.generate(PROJECT).unwrap();
 
     let exp_output = "\
 ============================================
@@ -351,7 +354,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let res = changelog.generate();
+    let res = changelog.generate(PROJECT);
 
     assert!(res.is_err());
     assert!(res
@@ -385,7 +388,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let res = changelog.generate();
+    let res = changelog.generate(PROJECT);
 
     assert!(res.is_err());
     assert!(res
@@ -427,7 +430,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate().unwrap();
+    let output = changelog.generate(PROJECT).unwrap();
 
     let exp_output = "\
 ============================================
@@ -484,7 +487,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate().unwrap();
+    let output = changelog.generate(PROJECT).unwrap();
 
     let exp_output = "\
 ============================================

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,13 +4,15 @@ mod mocks;
 
 use mkchlog::changelog;
 use mkchlog::changelog::Changelog;
+use mkchlog::config::Command;
 use mkchlog::git::Git;
 use mkchlog::template::Template;
 use mocks::GitCmdMock;
 use std::fs::File;
 
 const YAML_FILE: &str = "tests/mkchlog.yml";
-const PROJECT: Option<String> = None;
+const PROJECT_NONE: Option<String> = None;
+const COMMAND: Command = Command::Generate;
 
 #[test]
 fn it_produces_correct_output() {
@@ -27,6 +29,8 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         inherit: title
         title-is-enough: true
 
+.github/workflows/ci.yml
+
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Sun Oct 22 23:08:57 2023 +0200
@@ -40,6 +44,12 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
     changelog:
         section: features
         inherit: all
+
+.mkchlog.yml
+README.md
+src/lib.rs
+src/template.rs
+tests/mkchlog.yml
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -59,6 +69,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
+.github/workflows/test.yml
+Cargo.lock
+Cargo.toml
+README.md
+clippy.toml
+src/template.rs
+
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -77,6 +94,12 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             section: dev
             title-is-enough: true
+
+.github/workflows/changelog.yml
+.github/workflows/test.yml
+.mkchlog.yml
+tests/integration_test.rs
+tests/mkchlog.yml
 
 commit 1cc72956df91e2fd8c45e72983c4e1149f1ac3b3
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -98,6 +121,11 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                      working directory is **not** accessible by
                      unprivileged users you don't need to worry.
 
+src/bip324.cpp
+src/bip324.h
+src/crypto/chacha20poly1305.cpp
+src/crypto/chacha20poly1305.h
+
 commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:26:35 2023 +0200
@@ -112,6 +140,8 @@ Date:   Tue Jun 13 16:26:35 2023 +0200
         title: Improved processing speed by 10%
         title-is-enough: true
 
+src/key_io.cpp
+
 commit a1a654e256cc96e1c4b5a81845b5e3f3f0aa9ed3
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:25:29 2023 +0200
@@ -121,6 +151,8 @@ Date:   Tue Jun 13 16:25:29 2023 +0200
     We found 42 grammar mistakes that are fixed in this commit.
 
     changelog: skip
+
+README.md
 
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -134,7 +166,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features",
+        section: features
+
+src/changelog.rs",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -144,7 +178,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate(PROJECT).unwrap();
+    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -215,7 +249,10 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                      working directory is **not** accessible by
                      unprivileged users you don't need to worry.
 
-",
+src/bip324.cpp
+src/bip324.h
+src/crypto/chacha20poly1305.cpp
+src/crypto/chacha20poly1305.h",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -225,7 +262,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate(PROJECT).unwrap();
+    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -265,6 +302,12 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         section: features
         inherit: all
 
+.mkchlog.yml
+README.md
+src/lib.rs
+src/template.rs
+tests/mkchlog.yml
+
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 09:12:50 2023 +0200
@@ -283,6 +326,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
             section: features
             title-is-enough: true
 
+.github/workflows/test.yml
+Cargo.lock
+Cargo.toml
+README.md
+clippy.toml
+src/template.rs
+
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -295,7 +345,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features",
+        section: features
+
+src/changelog.rs",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -305,7 +357,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate(PROJECT).unwrap();
+    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -344,7 +396,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: unconfigured_section",
+        section: unconfigured_section
+
+src/changelog.rs",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -354,7 +408,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let res = changelog.generate(PROJECT);
+    let res = changelog.generate(PROJECT_NONE, COMMAND);
 
     assert!(res.is_err());
     assert!(res
@@ -378,7 +432,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        inherit: all",
+        inherit: all
+
+src/changelog.rs",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -388,7 +444,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let res = changelog.generate(PROJECT);
+    let res = changelog.generate(PROJECT_NONE, COMMAND);
 
     assert!(res.is_err());
     assert!(res
@@ -412,6 +468,8 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         inherit: title
         title-is-enough: true
 
+.github/workflows/ci.yml
+
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -420,7 +478,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features",
+        section: features
+
+src/changelog.rs",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -430,7 +490,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate(PROJECT).unwrap();
+    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -469,6 +529,12 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         The new `.mkchlog.yml` is heavily inspired by the original example with
         more sections, so we're more flexible in the future.
 
+.github/workflows/changelog.yml
+.github/workflows/test.yml
+.mkchlog.yml
+tests/integration_test.rs
+tests/mkchlog.yml
+
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -477,7 +543,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: dev",
+        section: dev
+
+.github/workflows/ci.yml",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -487,7 +555,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate(PROJECT).unwrap();
+    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -505,4 +573,85 @@ This configures github actions to test `mkchlog` as well as run it on its own re
 ============================================";
 
     assert_eq!(exp_output, output);
+}
+
+#[test]
+fn when_called_with_check_command_does_not_print_anything() {
+    let mocked_log = String::from(
+        "\
+commit 1cc72956df91e2fd8c45e72983c4e1149f1ac3b3
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Jun 13 16:27:59 2023 +0200
+
+    Fixed TOCTOU race condition when opening file
+
+    Previously we checked the file permissions before opening
+    the file now we check the metadata using file descriptor
+    after opening the file. (before reading)
+
+    changelog:
+        section: security:vuln_fixes
+        title: Fixed vulnerability related to opening files
+        description: The application was vulnerable to attacks
+                     if the attacker had access to the working
+                     directory. If you run this in such
+                     enviroment you should update ASAP. If your
+                     working directory is **not** accessible by
+                     unprivileged users you don't need to worry.
+
+src/bip324.cpp
+src/bip324.h
+src/crypto/chacha20poly1305.cpp
+src/crypto/chacha20poly1305.h",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let output = changelog.generate(PROJECT_NONE, Command::Check).unwrap();
+
+    let exp_output = "";
+
+    assert_eq!(exp_output, output);
+}
+
+#[test]
+fn when_called_with_check_command_fails_if_commits_invalid() {
+    let mocked_log = String::from(
+        "\
+commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Jun 13 16:24:22 2023 +0200
+
+    Added ability to skip commits.
+
+    This allows commits to be skipped by typing 'changelog: skip'
+    at the end of the commit. This is mainly useful for typo
+    fixes or other things irrelevant to the user of a project.
+
+    changelog:
+        inherit: all
+        section: unconfigured_section
+
+src/changelog.rs",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let res = changelog.generate(PROJECT_NONE, Command::Check);
+
+    assert!(res.is_err());
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .starts_with("Unknown section 'unconfigured_section' in changelog message"));
 }

--- a/tests/integration_test_projects.rs
+++ b/tests/integration_test_projects.rs
@@ -2,6 +2,7 @@ mod mocks;
 
 use mkchlog::changelog;
 use mkchlog::changelog::Changelog;
+use mkchlog::config::Command;
 use mkchlog::git::Git;
 use mkchlog::template::Template;
 use mocks::GitCmdMock;
@@ -9,6 +10,7 @@ use std::fs::File;
 
 const YAML_FILE_PROJECTS: &str = "tests/mkchlog_projects.yml";
 const YAML_FILE_SINCE_COMMIT: &str = "tests/mkchlog_projects_since_commit.yml";
+const COMMAND: Command = Command::Generate;
 
 #[test]
 fn it_produces_correct_output_for_project1() {
@@ -29,6 +31,8 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
+mkchlog-action/README.md
+
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -40,6 +44,8 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
+
+mkchlog/.github/workflows/ci.yml
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -56,6 +62,28 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
+mkchlog/.mkchlog.yml
+mkchlog/README.md
+mkchlog/src/lib.rs
+mkchlog/src/template.rs
+mkchlog/tests/mkchlog.yml
+
+commit ac0df22c6b5c9e4ec387b61b7997d420a1b6d36c
+Author: Vojtěch Toman <cry.wolf@centrum.cz>
+Date:   Tue Oct 31 13:46:59 2023 +0100
+
+    Allow parsing commit(s) from stdin
+
+    It is possible to check the commit before it is actually commited. Useful to use in a commit-msg git hook.
+
+    changelog:
+        project:main
+        section: features
+        inherit: all
+
+.githooks/commit-msg
+README.md
+
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -68,6 +96,9 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
+
+mkchlog-action/node_modules/libmkchlog/libmkchlog.js
+mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -88,6 +119,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
+mkchlog/.github/workflows/test.yml
+mkchlog/Cargo.lock
+mkchlog/Cargo.toml
+mkchlog/README.md
+mkchlog/clippy.toml
+mkchlog/src/template.rs
+
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -107,7 +145,12 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
             project: mkchlog
             section: dev
             title-is-enough: true
-",
+
+mkchlog/.github/workflows/changelog.yml
+mkchlog/.github/workflows/test.yml
+mkchlog/.mkchlog.yml
+mkchlog/tests/integration_test.rs
+mkchlog/tests/mkchlog.yml",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -118,7 +161,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     let mut changelog = Changelog::new(&mut template, git);
 
     let project = Some("mkchlog".to_owned());
-    let output = changelog.generate(project).unwrap();
+    let output = changelog.generate(project, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -163,6 +206,8 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
+mkchlog-action/README.md
+
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -174,6 +219,8 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
+
+mkchlog/.github/workflows/ci.yml
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -190,6 +237,12 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
+mkchlog/.mkchlog.yml
+mkchlog/README.md
+mkchlog/src/lib.rs
+mkchlog/src/template.rs
+mkchlog/tests/mkchlog.yml
+
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -202,6 +255,9 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
+
+mkchlog-action/node_modules/libmkchlog/libmkchlog.js
+mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -222,6 +278,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
+mkchlog/.github/workflows/test.yml
+mkchlog/Cargo.lock
+mkchlog/mkchlog/Cargo.toml
+mkchlog/README.md
+mkchlog/clippy.toml
+mkchlog/src/template.rs
+
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -241,7 +304,12 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
             project: mkchlog
             section: dev
             title-is-enough: true
-",
+
+mkchlog/.github/workflows/changelog.yml
+mkchlog/.github/workflows/test.yml
+mkchlog/.mkchlog.yml
+mkchlog/tests/integration_test.rs
+mkchlog/tests/mkchlog.yml",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -252,7 +320,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     let mut changelog = Changelog::new(&mut template, git);
 
     let project = Some("mkchlog-action".to_owned());
-    let output = changelog.generate(project).unwrap();
+    let output = changelog.generate(project, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -273,7 +341,7 @@ This updates the wasm module to one which was compiled with `--release`.
 }
 
 #[test]
-fn fails_when_called_with_incorrect_project_argument_provided() {
+fn fails_when_called_with_incorrect_project_argument_provided_when_calling_the_app() {
     let mocked_log = String::from("");
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -284,13 +352,91 @@ fn fails_when_called_with_incorrect_project_argument_provided() {
     let mut changelog = Changelog::new(&mut template, git);
 
     let project = Some("nonsense".to_owned());
-    let res = changelog.generate(project);
+    let res = changelog.generate(project, COMMAND);
 
     assert!(res.is_err());
     assert!(res
         .unwrap_err()
         .to_string()
         .starts_with("Project 'nonsense' not configured in config file"));
+}
+
+#[test]
+fn fails_when_commit_contains_invalid_project_name() {
+    let mocked_log = String::from(
+        "\
+commit df841802133a1ad7556245bdce59417270de5c3f
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 25 10:12:50 2023 +0200
+
+    Add configuration instructions to README.md
+
+    The `fetch-depth` configuration isn't obvious for newbies so this
+    documents it.
+
+    changelog:
+        project: wrong-name
+        section: doc
+        inherit: title
+        title-is-enough: true
+
+README.md
+    ",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_PROJECTS).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog".to_owned());
+    let res = changelog.generate(project, COMMAND);
+
+    assert!(res.is_err());
+    assert!(res.unwrap_err().to_string().starts_with(
+        "Incorrect (not allowed in config file) project name 'wrong-name' in changelog message"
+    ));
+}
+
+#[test]
+fn fails_when_commit_changes_files_that_are_not_in_project_directory() {
+    let mocked_log = String::from(
+        "\
+commit ac0df22c6b5c9e4ec387b61b7997d420a1b6d36c
+Author: Vojtěch Toman <cry.wolf@centrum.cz>
+Date:   Tue Oct 31 13:46:59 2023 +0100
+
+    Allow parsing commit(s) from stdin
+
+    It is possible to check the commit before it is actually commited. Useful to use in a commit-msg git hook.
+
+    changelog:
+        project: main
+        section: features
+        inherit: all
+
+.githooks/commit-msg
+README.md
+src/config.rs",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_PROJECTS).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog".to_owned());
+    let res = changelog.generate(project, COMMAND);
+
+    assert!(res.is_err());
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .starts_with("File: 'src/config.rs' does not belong to project 'main' in commit:"));
 }
 
 #[test]
@@ -312,6 +458,8 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
+mkchlog-action/README.md
+
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -323,6 +471,8 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
+
+mkchlog/.github/workflows/ci.yml
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -339,6 +489,12 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
+mkchlog/.mkchlog.yml
+mkchlog/README.md
+mkchlog/src/lib.rs
+mkchlog/src/template.rs
+mkchlog/tests/mkchlog.yml
+
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -351,6 +507,9 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
+
+mkchlog-action/node_modules/libmkchlog/libmkchlog.js
+mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -370,6 +529,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
+.github/workflows/test.yml
+Cargo.lock
+Cargo.toml
+README.md
+clippy.toml
+src/template.rs
+
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -388,7 +554,12 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             section: dev
             title-is-enough: true
-",
+
+.github/workflows/changelog.yml
+.github/workflows/test.yml
+.mkchlog.yml
+tests/integration_test.rs
+tests/mkchlog.yml",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -399,7 +570,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     let mut changelog = Changelog::new(&mut template, git);
 
     let project = Some("mkchlog".to_owned());
-    let output = changelog.generate(project).unwrap();
+    let output = changelog.generate(project, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -444,6 +615,8 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
+mkchlog-action/README.md
+
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -455,6 +628,9 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
+
+mkchlog/.github/workflows/ci.yml
+mkchlog/README.md
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -471,6 +647,12 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
+mkchlog/.mkchlog.yml
+mkchlog/README.md
+mkchlog/src/lib.rs
+mkchlog/src/template.rs
+mkchlog/tests/mkchlog.yml
+
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -483,6 +665,9 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
+
+mkchlog-action/node_modules/libmkchlog/libmkchlog.js
+mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -502,6 +687,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
+.github/workflows/test.yml
+Cargo.lock
+Cargo.toml
+README.md
+clippy.toml
+src/template.rs
+
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -520,7 +712,12 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             section: dev
             title-is-enough: true
-",
+
+.github/workflows/changelog.yml
+.github/workflows/test.yml
+.mkchlog.yml
+tests/integration_test.rs
+tests/mkchlog.yml",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -531,7 +728,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     let mut changelog = Changelog::new(&mut template, git);
 
     let project = Some("mkchlog-action".to_owned());
-    let output = changelog.generate(project).unwrap();
+    let output = changelog.generate(project, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -549,4 +746,44 @@ This updates the wasm module to one which was compiled with `--release`.
 ============================================";
 
     assert_eq!(exp_output, output);
+}
+
+#[test]
+fn when_called_with_check_command_fails_if_commits_are_invalid() {
+    // test that we can call it without providing project name when just checking commits, not generating changelog
+    // and it will correctly find commit with invalid or missing project
+
+    let mocked_log = String::from(
+        "\
+commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Jun 13 16:24:22 2023 +0200
+
+    Added ability to skip commits.
+
+    This allows commits to be skipped by typing 'changelog: skip'
+    at the end of the commit. This is mainly useful for typo
+    fixes or other things irrelevant to the user of a project.
+
+    changelog:
+        inherit: all
+        section: feature
+
+src/changelog.rs",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_SINCE_COMMIT).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let res = changelog.generate(None, Command::Check);
+
+    assert!(res.is_err());
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .starts_with("Missing 'project' key in changelog message:"));
 }

--- a/tests/integration_test_projects.rs
+++ b/tests/integration_test_projects.rs
@@ -1,0 +1,552 @@
+mod mocks;
+
+use mkchlog::changelog;
+use mkchlog::changelog::Changelog;
+use mkchlog::git::Git;
+use mkchlog::template::Template;
+use mocks::GitCmdMock;
+use std::fs::File;
+
+const YAML_FILE_PROJECTS: &str = "tests/mkchlog_projects.yml";
+const YAML_FILE_SINCE_COMMIT: &str = "tests/mkchlog_projects_since_commit.yml";
+
+#[test]
+fn it_produces_correct_output_for_project1() {
+    let mocked_log = String::from(
+        "\
+commit df841802133a1ad7556245bdce59417270de5c3f
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 25 10:12:50 2023 +0200
+
+    Add configuration instructions to README.md
+
+    The `fetch-depth` configuration isn't obvious for newbies so this
+    documents it.
+
+    changelog:
+        project: mkchlog-action
+        section: doc
+        inherit: title
+        title-is-enough: true
+
+commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Oct 24 19:17:09 2023 +0200
+
+    Setup CI
+
+    changelog:
+        project: mkchlog
+        section: dev
+        inherit: title
+        title-is-enough: true
+
+commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Sun Oct 22 23:08:57 2023 +0200
+
+    Allow configuring commit ID in yaml
+
+    This adds a field `skip-commits-up-to` into top level of yaml config so
+    that users don't have to remember what to supply in `-c` argument every
+    time.
+
+    changelog:
+        section: features
+        inherit: all
+        project: mkchlog
+
+commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 10:12:50 2023 +0200
+
+    Publish release version rather than debug
+
+    This updates the wasm module to one which was compiled with `--release`.
+
+    changelog:
+        project: mkchlog-action
+        section: perf
+        inherit: all
+
+commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 09:12:50 2023 +0200
+
+    Support building on Debian Bookworm
+
+    This change lowers the requirements for dependencies so that the code
+    compiles on Rust 1.63 which is in Debian Bookworm. Further, the
+    dependencies are lowered such that the packages vendored in Debian
+    Bookworm can be used directly.
+
+    This uses version ranges so that the newest crates can still be used
+    (they didn't break our code).
+
+    changelog:
+        project: mkchlog
+        section: features
+        title-is-enough: true
+
+commit 624c947820cba6c0665b84bfc139f209277f2a95
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sat Oct 21 19:00:27 2023 +0200
+
+    Setup Github Actions
+
+    This configures github actions to test `mkchlog` as well as run it on
+    its own repository. Also moved `.mkchlog.yml`, which was used in test,
+    to `tests/mkchlog.yml` and created custom `.mkchlog.yml` that's used in
+    this project.
+
+    The new `.mkchlog.yml` is heavily inspired by the original example with
+    more sections, so we're more flexible in the future. Includes a section
+    used in this commit. :)
+
+    changelog:
+            project: mkchlog
+            section: dev
+            title-is-enough: true
+",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_PROJECTS).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog".to_owned());
+    let output = changelog.generate(project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## New features
+
+* Support building on Debian Bookworm
+
+### Allow configuring commit ID in yaml
+
+This adds a field `skip-commits-up-to` into top level of yaml config so that users don't have to remember what to supply in `-c` argument every time.
+
+## Development
+
+Internal development changes
+
+* Setup CI
+
+* Setup Github Actions
+
+============================================";
+
+    assert_eq!(exp_output, output);
+}
+
+#[test]
+fn it_produces_correct_output_for_project2() {
+    let mocked_log = String::from(
+        "\
+commit df841802133a1ad7556245bdce59417270de5c3f
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 25 10:12:50 2023 +0200
+
+    Add configuration instructions to README.md
+
+    The `fetch-depth` configuration isn't obvious for newbies so this
+    documents it.
+
+    changelog:
+        project: mkchlog-action
+        section: doc
+        inherit: title
+        title-is-enough: true
+
+commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Oct 24 19:17:09 2023 +0200
+
+    Setup CI
+
+    changelog:
+        project: mkchlog
+        section: dev
+        inherit: title
+        title-is-enough: true
+
+commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Sun Oct 22 23:08:57 2023 +0200
+
+    Allow configuring commit ID in yaml
+
+    This adds a field `skip-commits-up-to` into top level of yaml config so
+    that users don't have to remember what to supply in `-c` argument every
+    time.
+
+    changelog:
+        section: features
+        inherit: all
+        project: mkchlog
+
+commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 10:12:50 2023 +0200
+
+    Publish release version rather than debug
+
+    This updates the wasm module to one which was compiled with `--release`.
+
+    changelog:
+        project: mkchlog-action
+        section: perf
+        inherit: all
+
+commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 09:12:50 2023 +0200
+
+    Support building on Debian Bookworm
+
+    This change lowers the requirements for dependencies so that the code
+    compiles on Rust 1.63 which is in Debian Bookworm. Further, the
+    dependencies are lowered such that the packages vendored in Debian
+    Bookworm can be used directly.
+
+    This uses version ranges so that the newest crates can still be used
+    (they didn't break our code).
+
+    changelog:
+        project: mkchlog
+        section: features
+        title-is-enough: true
+
+commit 624c947820cba6c0665b84bfc139f209277f2a95
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sat Oct 21 19:00:27 2023 +0200
+
+    Setup Github Actions
+
+    This configures github actions to test `mkchlog` as well as run it on
+    its own repository. Also moved `.mkchlog.yml`, which was used in test,
+    to `tests/mkchlog.yml` and created custom `.mkchlog.yml` that's used in
+    this project.
+
+    The new `.mkchlog.yml` is heavily inspired by the original example with
+    more sections, so we're more flexible in the future. Includes a section
+    used in this commit. :)
+
+    changelog:
+            project: mkchlog
+            section: dev
+            title-is-enough: true
+",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_PROJECTS).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog-action".to_owned());
+    let output = changelog.generate(project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## Performance improvements
+
+### Publish release version rather than debug
+
+This updates the wasm module to one which was compiled with `--release`.
+
+## Documentation changes
+
+* Add configuration instructions to README.md
+
+============================================";
+
+    assert_eq!(exp_output, output);
+}
+
+#[test]
+fn fails_when_called_with_incorrect_project_argument_provided() {
+    let mocked_log = String::from("");
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_PROJECTS).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("nonsense".to_owned());
+    let res = changelog.generate(project);
+
+    assert!(res.is_err());
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .starts_with("Project 'nonsense' not configured in config file"));
+}
+
+#[test]
+fn it_produces_correct_output_for_project1_since_commit() {
+    let mocked_log = String::from(
+        "\
+commit df841802133a1ad7556245bdce59417270de5c3f
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 25 10:12:50 2023 +0200
+
+    Add configuration instructions to README.md
+
+    The `fetch-depth` configuration isn't obvious for newbies so this
+    documents it.
+
+    changelog:
+        project: mkchlog-action
+        section: doc
+        inherit: title
+        title-is-enough: true
+
+commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Oct 24 19:17:09 2023 +0200
+
+    Setup CI
+
+    changelog:
+        project: mkchlog
+        section: dev
+        inherit: title
+        title-is-enough: true
+
+commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Sun Oct 22 23:08:57 2023 +0200
+
+    Allow configuring commit ID in yaml
+
+    This adds a field `skip-commits-up-to` into top level of yaml config so
+    that users don't have to remember what to supply in `-c` argument every
+    time.
+
+    changelog:
+        section: features
+        inherit: all
+        project: mkchlog
+
+commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 10:12:50 2023 +0200
+
+    Publish release version rather than debug
+
+    This updates the wasm module to one which was compiled with `--release`.
+
+    changelog:
+        project: mkchlog-action
+        section: perf
+        inherit: all
+
+commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 09:12:50 2023 +0200
+
+    Support building on Debian Bookworm
+
+    This change lowers the requirements for dependencies so that the code
+    compiles on Rust 1.63 which is in Debian Bookworm. Further, the
+    dependencies are lowered such that the packages vendored in Debian
+    Bookworm can be used directly.
+
+    This uses version ranges so that the newest crates can still be used
+    (they didn't break our code).
+
+    changelog:
+        section: features
+        title-is-enough: true
+
+commit 624c947820cba6c0665b84bfc139f209277f2a95
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sat Oct 21 19:00:27 2023 +0200
+
+    Setup Github Actions
+
+    This configures github actions to test `mkchlog` as well as run it on
+    its own repository. Also moved `.mkchlog.yml`, which was used in test,
+    to `tests/mkchlog.yml` and created custom `.mkchlog.yml` that's used in
+    this project.
+
+    The new `.mkchlog.yml` is heavily inspired by the original example with
+    more sections, so we're more flexible in the future. Includes a section
+    used in this commit. :)
+
+    changelog:
+            section: dev
+            title-is-enough: true
+",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_SINCE_COMMIT).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog".to_owned());
+    let output = changelog.generate(project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## New features
+
+* Support building on Debian Bookworm
+
+### Allow configuring commit ID in yaml
+
+This adds a field `skip-commits-up-to` into top level of yaml config so that users don't have to remember what to supply in `-c` argument every time.
+
+## Development
+
+Internal development changes
+
+* Setup CI
+
+* Setup Github Actions
+
+============================================";
+
+    assert_eq!(exp_output, output);
+}
+
+#[test]
+fn it_produces_correct_output_for_project2_since_commit() {
+    let mocked_log = String::from(
+        "\
+commit df841802133a1ad7556245bdce59417270de5c3f
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 25 10:12:50 2023 +0200
+
+    Add configuration instructions to README.md
+
+    The `fetch-depth` configuration isn't obvious for newbies so this
+    documents it.
+
+    changelog:
+        project: mkchlog-action
+        section: doc
+        inherit: title
+        title-is-enough: true
+
+commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Oct 24 19:17:09 2023 +0200
+
+    Setup CI
+
+    changelog:
+        project: mkchlog
+        section: dev
+        inherit: title
+        title-is-enough: true
+
+commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Sun Oct 22 23:08:57 2023 +0200
+
+    Allow configuring commit ID in yaml
+
+    This adds a field `skip-commits-up-to` into top level of yaml config so
+    that users don't have to remember what to supply in `-c` argument every
+    time.
+
+    changelog:
+        section: features
+        inherit: all
+        project: mkchlog
+
+commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 10:12:50 2023 +0200
+
+    Publish release version rather than debug
+
+    This updates the wasm module to one which was compiled with `--release`.
+
+    changelog:
+        project: mkchlog-action
+        section: perf
+        inherit: all
+
+commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 09:12:50 2023 +0200
+
+    Support building on Debian Bookworm
+
+    This change lowers the requirements for dependencies so that the code
+    compiles on Rust 1.63 which is in Debian Bookworm. Further, the
+    dependencies are lowered such that the packages vendored in Debian
+    Bookworm can be used directly.
+
+    This uses version ranges so that the newest crates can still be used
+    (they didn't break our code).
+
+    changelog:
+        section: features
+        title-is-enough: true
+
+commit 624c947820cba6c0665b84bfc139f209277f2a95
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sat Oct 21 19:00:27 2023 +0200
+
+    Setup Github Actions
+
+    This configures github actions to test `mkchlog` as well as run it on
+    its own repository. Also moved `.mkchlog.yml`, which was used in test,
+    to `tests/mkchlog.yml` and created custom `.mkchlog.yml` that's used in
+    this project.
+
+    The new `.mkchlog.yml` is heavily inspired by the original example with
+    more sections, so we're more flexible in the future. Includes a section
+    used in this commit. :)
+
+    changelog:
+            section: dev
+            title-is-enough: true
+",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_SINCE_COMMIT).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog-action".to_owned());
+    let output = changelog.generate(project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## Performance improvements
+
+### Publish release version rather than debug
+
+This updates the wasm module to one which was compiled with `--release`.
+
+## Documentation changes
+
+* Add configuration instructions to README.md
+
+============================================";
+
+    assert_eq!(exp_output, output);
+}

--- a/tests/mkchlog_projects.yml
+++ b/tests/mkchlog_projects.yml
@@ -1,0 +1,28 @@
+skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
+
+projects:
+    names: [mkchlog, mkchlog-action] # list of project names
+
+sections:
+    # section identifier selected by project maintainer
+    security:
+        # The header presented to the user
+        title: Security
+        # desctiption is optional and will appear above changes
+        description: This section contains very important security-related changes.
+        subsections:
+            vuln_fixes:
+                title: Fixed vulnerabilities
+    features:
+        title: New features
+    bug_fixes:
+        title: Fixed bugs
+    breaking:
+        title: Breaking changes
+    perf:
+        title: Performance improvements
+    doc:
+        title: Documentation changes
+    dev:
+        title: Development
+        description: Internal development changes

--- a/tests/mkchlog_projects.yml
+++ b/tests/mkchlog_projects.yml
@@ -1,7 +1,10 @@
 skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
 
 projects:
-    names: [mkchlog, mkchlog-action] # list of project names
+    list:  # list of allowed projects
+    - main: [".", .github, .githooks] # name: [directory1, directory2]
+    - mkchlog: [mkchlog] # name: [directory]
+    - mkchlog-action: [mkchlog-action] # name: [directory]
 
 sections:
     # section identifier selected by project maintainer

--- a/tests/mkchlog_projects_since_commit.yml
+++ b/tests/mkchlog_projects_since_commit.yml
@@ -1,7 +1,11 @@
 skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
 
 projects:
-    names: [mkchlog, mkchlog-action] # list of project names
+    list:  # list of allowed projects
+    - main: [".", .github, .githooks] # name: [directory1, directory2]
+    - mkchlog: [mkchlog] # name: [directory]
+    - mkchlog-action: [mkchlog-action] # name: [directory]
+
     since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER
     default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME
 

--- a/tests/mkchlog_projects_since_commit.yml
+++ b/tests/mkchlog_projects_since_commit.yml
@@ -1,0 +1,30 @@
+skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
+
+projects:
+    names: [mkchlog, mkchlog-action] # list of project names
+    since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER
+    default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME
+
+sections:
+    # section identifier selected by project maintainer
+    security:
+        # The header presented to the user
+        title: Security
+        # desctiption is optional and will appear above changes
+        description: This section contains very important security-related changes.
+        subsections:
+            vuln_fixes:
+                title: Fixed vulnerabilities
+    features:
+        title: New features
+    bug_fixes:
+        title: Fixed bugs
+    breaking:
+        title: Breaking changes
+    perf:
+        title: Performance improvements
+    doc:
+        title: Documentation changes
+    dev:
+        title: Development
+        description: Internal development changes

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -32,7 +32,7 @@ fn run(config: &str, git_callback: js_sys::Function) -> Result<(), Box<dyn std::
 
     let mut changelog = Changelog::new(&mut template, git);
 
-    changelog.generate()?;
+    changelog.generate(None)?;
     Ok(())
 }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -19,6 +19,7 @@ pub fn check(config: &str, git_callback: js_sys::Function) -> Result<(), JsValue
 fn run(config: &str, git_callback: js_sys::Function) -> Result<(), Box<dyn std::error::Error>> {
     use mkchlog::changelog::Changelog;
     use mkchlog::changelog::Changes;
+    use mkchlog::config::Command;
     use mkchlog::template::Template;
 
     let mut template = Template::<Changes>::from_str(config)?;
@@ -32,7 +33,7 @@ fn run(config: &str, git_callback: js_sys::Function) -> Result<(), Box<dyn std::
 
     let mut changelog = Changelog::new(&mut template, git);
 
-    changelog.generate(None)?;
+    changelog.generate(None, Command::Check)?;
     Ok(())
 }
 


### PR DESCRIPTION
Some repositories host multiple projects that are related but have disjoint changelogs. This is typical for multi-crate workspaces in Rust. When configured as multi-project repo and using `project:` keyword in commit changelogs this feature allows to generate separate changelogs.

closes #14