### PR TITLE
Support multi-project repositories, ver. 2

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,13 +1,7 @@
 #!/bin/sh
 COMMIT_MSG_FILE=$1
 
-FAKE_COMMIT_MESSAGE="$(cat "$COMMIT_MSG_FILE" | grep -v '^#')"
-
-MODIFIED_FILES=$(git diff-index --cached --name-only HEAD)
-
-FAKE_COMMIT_MESSAGE="${FAKE_COMMIT_MESSAGE}\n\n${MODIFIED_FILES}"
-
-if ! echo "$FAKE_COMMIT_MESSAGE" | cargo run -- --from-stdin check ; then
-  >&2 echo "Please follow mkchlog rules"
+if ! cat "$COMMIT_MSG_FILE" | grep -v '^#' | cargo run -- --from-stdin check ; then
+  >&2 echo "---> Please follow mkchlog rules"
   exit 1
 fi

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,6 +1,13 @@
 #!/bin/sh
-if ! cat "$1" | grep -v '^#' | cargo run -- --from-stdin check ; then
+COMMIT_MSG_FILE=$1
+
+FAKE_COMMIT_MESSAGE="$(cat "$COMMIT_MSG_FILE" | grep -v '^#')"
+
+MODIFIED_FILES=$(git diff-index --cached --name-only HEAD)
+
+FAKE_COMMIT_MESSAGE="${FAKE_COMMIT_MESSAGE}\n\n${MODIFIED_FILES}"
+
+if ! echo "$FAKE_COMMIT_MESSAGE" | cargo run -- --from-stdin check ; then
   >&2 echo "Please follow mkchlog rules"
   exit 1
 fi
-

--- a/.githooks/commit_template.txt
+++ b/.githooks/commit_template.txt
@@ -1,6 +1,5 @@
 #
-# Uncomment 'changelog:' part and at least fill in correct 'section'
-# from the provided list of valid sections above.
+# Fill in correct 'section' from the provided list of valid sections above.
 #
 # First line of the commit message serves as a title in the changelog
 # and thus should be very short.
@@ -9,7 +8,7 @@
 # feel free to be detailed.
 #
 # If you do not want to include your commit message into the changelog,
-# you can use 'changelog: skip' and let rest of the changelog lines commented out.
+# simply use 'changelog: skip' and remove the rest of the changelog: part.
 #
 # For more information how to use the tool, see README.md
 #

--- a/.githooks/commit_template.txt
+++ b/.githooks/commit_template.txt
@@ -1,0 +1,14 @@
+#
+# Uncomment 'changelog:' part and at least fill in correct 'section'
+# from the provided list of valid sections above.
+#
+# First line of the commit message serves as a title in the changelog
+# and thus should be very short.
+#
+# Next can be multi-line description of commit, feel free to be detailed.
+#
+# If you do not want to include your commit message into the changelog,
+# you can use 'changelog: skip' and let rest of the changelog lines commented out.
+#
+# For more information how to use the tool, see README.md
+#

--- a/.githooks/commit_template.txt
+++ b/.githooks/commit_template.txt
@@ -8,7 +8,7 @@
 # feel free to be detailed.
 #
 # If you do not want to include your commit message into the changelog,
-# simply use 'changelog: skip' and remove the rest of the changelog: part.
+# simply use 'changelog: skip' and remove or comment out the rest of the changelog: part.
 #
 # For more information how to use the tool, see README.md
 #

--- a/.githooks/commit_template.txt
+++ b/.githooks/commit_template.txt
@@ -5,7 +5,8 @@
 # First line of the commit message serves as a title in the changelog
 # and thus should be very short.
 #
-# Next can be multi-line description of commit, feel free to be detailed.
+# After an empty line you can add multi-line description of commit,
+# feel free to be detailed.
 #
 # If you do not want to include your commit message into the changelog,
 # you can use 'changelog: skip' and let rest of the changelog lines commented out.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --type=bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+exec git diff-index --check --cached $against -- || exit 1
+
+# Check that code lints cleanly.
+cargo clippy --all-features -- -D warnings || exit 1
+
+# Check that there are no formatting issues.
+cargo fmt --check || exit 1

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+SHA1=$3
+
+MODIFIED_FILES=$(git diff-index --cached --name-only HEAD)
+
+if ! COMMIT_TEMPLATE=$(echo "$MODIFIED_FILES" | cargo run -- commit-template) ; then
+  >&2 echo "Please follow mkchlog rules"
+  exit 1
+fi
+
+echo "$(echo "$COMMIT_TEMPLATE" | cat - "$COMMIT_MSG_FILE")" > "$COMMIT_MSG_FILE"

--- a/.mkchlog.yml
+++ b/.mkchlog.yml
@@ -18,6 +18,8 @@ sections:
         title: Breaking changes
     perf:
         title: Performance improvements
+    doc:
+        title: Documentation changes
     dev:
         title: Development
         description: Internal development changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "clap",
  "indexmap",
  "regex",
+ "serde",
  "serde_yaml",
 ]
 
@@ -300,6 +301,20 @@ name = "serde"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.164"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
 
 [[package]]
 name = "serde_yaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ repository = "https://github.com/crywolf/mkchlog"
 clap = { version = "4.0.32", features = ["derive"] }
 indexmap = { version = ">= 1.5.2, < 3.0.0" }
 regex = "1.7.1"
+serde = { version = "1", features = ["derive"]}
 serde_yaml = { version = ">= 0.8.26, < 0.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ repository = "https://github.com/crywolf/mkchlog"
 clap = { version = "4.0.32", features = ["derive"] }
 indexmap = { version = ">= 1.5.2, < 3.0.0" }
 regex = "1.7.1"
-serde_yaml = ">= 0.8.26, < 0.10.0"
+serde_yaml = { version = ">= 0.8.26, < 0.10.0" }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,67 @@
+# Detailed explanation
+
+Final changelog output can have "title" and "description", but only "title" is required. By defaut the first line in the commit message is used as "title" and the rest is used as "description" so the whole commit message will be included in the changelog output.
+
+This is OK when the commit message is equally useful for developers and users.
+
+Often this is not the case. If you want to use differrent title or description, use `title` and/or `description` field in the `changelog:` part of the commit message.
+
+## Cookbook examples
+
+```yaml
+This is the simplest version
+
+changelog:
+  section: features
+```
+
+```yaml
+This is "title" from the commit message
+
+This is "description" from the commit message. It can be longer.
+
+changelog:
+  section: features
+```
+
+```yaml
+This "title" will not be present in changelog output
+
+This "description" will not be present in changelog output as well.
+
+changelog:
+  section: features
+  title: This will override "title" from the commit message
+  description: This will override "description" from the commit message
+```
+
+```yaml
+This is "title" from the commit message
+
+This "description" will not be present in changelog output.
+
+changelog:
+  section: features
+  only-title: true
+```
+
+```yaml
+This is "title" from the commit message
+
+This "description" will not be present in changelog output.
+
+changelog:
+  section: features
+  description: This will override "description" from the commit message
+```
+
+```yaml
+This "title" will not be present in changelog output
+
+This "description" will not be present in changelog output.
+
+changelog:
+  section: features
+  title: This will override "title" from the commit message
+  only-title: true
+```

--- a/README.md
+++ b/README.md
@@ -181,13 +181,19 @@ Some repositories host multiple projects that are related but should have disjoi
 # .mkchlog.yml
 # top level
 projects:
-    list:  # list of allowed projects
-    - main: [".", .github, .githooks] # name: [directory1, directory2, ...]
-    - mkchlog: [mkchlog] # name: [directory]
-    - mkchlog-action: [mkchlog-action] # name: [directory]
+  list: # list of allowed projects
+    - project:
+        name: main
+        dirs: [".", .github, .githooks] # list of directories the project is contained in
+    - project:
+        name: mkchlog
+        dirs: [mkchlog]
+    - project:
+        name: mkchlog-action
+        dirs: [mkchlog-action]
 
-    since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER [optional]
-    default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME [optional]
+  since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER [optional]
+  default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME [optional]
 ```
 
 If projects list is provided then git commit must contain `project: x` in the changelog message where `x` is one of the specified project names. After a project name, the list of directories the project is contained in, must be provided. Project `main` in the example above is the "root" project that contains all files in the project root directory, plus other directories that do not belong to other projects.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ at the end of the commit. This is mainly useful for typo
 fixes or other things irrelevant to the user of a project.
 
 changelog:
-    inherit: all
     section: features
 ```
 
@@ -134,7 +133,6 @@ This adds a field `skip-commits-up-to` into top level of yaml config so that use
 
 changelog:
     section: features
-    inherit: all
 ```
 
 ### Example output
@@ -210,7 +208,6 @@ This updates the wasm module to one which was compiled with `--release`.
 changelog:
     project: mkchlog-action
     section: perf
-    inherit: all
 ```
 
 #### Usage
@@ -239,14 +236,14 @@ To use prepared commit message template use the following command:
 
 Commit messages should contain descriptive information about the change.
 However not all of it is suitable to be in the changelog.
-Each commit must be explicitly marked as either skipped or has some basic information filled.
-Commits with `changelog: skip` will obviously not be included in the changelog.
-Commits with `inherit: all` will simply include both title and description of the commit in the changelog.
-This should be used when the commit message and description is equally useful for developers and users.
-`inherit` could also accept additional options like `title` to only copy the title.
-`section` is mandatory and defines in which section the change belongs.
+Each commit must be explicitly marked as either skipped or has some basic information filled. Commits with `changelog: skip` will obviously not be included in the changelog.
 
-`title` and `description` are those intended for the user.
+By default both **title** (first line of the commit message) and **description** (rest of the commit message if present) will be included in the changelog.
+This should be used when the commit message and description is equally useful for developers and users.
+
+`section` is mandatory and defines in which section of the changelog the change belongs.
+
+`title` and `description` fields are those intended for the user and can override the default values extracted from the commit message.
 The fictious "TOCTOU vulnerability fix" commit message above is hopefully a clear example.
 For users it describes how it impacts them while for programmers it explains technical details of the issue.
 `title-is-enough: true` explicitly opts-out of description, intended for situation when additional information is not needed for the user.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ You can provide additional options:
 * Commit number to start. This one and previous commits will be skipped. By default, all commit messages are checked. (This option can be also specified in `.mkchlog.yml`.)
 * Config (template) file name [default value is `.mkchlog.yml`]
 * Path to the git repository [default value is the current directory]. (This option can be also specified in `.mkchlog.yml`.)
-* `--from-stdin` Read commit(s) from stdin. Useful to use in a commit-msg git hook.
 
 `mkchlog -c 7c85bee4303d56bededdfacf8fbb7bdc68e2195b -f .mkchlog.yml -g ../git-mkchlog-test/ gen`
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ To use locally configured githooks for the development you can run in the root d
 
 Alternatively add symlinks in your .git/hooks directory to any of the provided githooks.
 
+To use prepared commit message template use the following command:
+
+`git config --local commit.template .githooks/commit_template.txt`
+
 ## Explanation
 
 (Rationale, idea and motivation by [Kixunil](https://github.com/Kixunil))

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Avoiding allocations like this introduces 10% speedup.
 changelog:
     section: perf
     title: Improve processing speed by 10%
-    title-is-enough: true
+    only-title: true
 ```
 
 ```
@@ -123,7 +123,7 @@ more sections, so we're more flexible in the future.
 
 changelog:
 	section: dev
-	title-is-enough: true
+	only-title: true
 ```
 
 ```
@@ -246,7 +246,7 @@ This should be used when the commit message and description is equally useful fo
 `title` and `description` fields are those intended for the user and can override the default values extracted from the commit message.
 The fictious "TOCTOU vulnerability fix" commit message above is hopefully a clear example.
 For users it describes how it impacts them while for programmers it explains technical details of the issue.
-`title-is-enough: true` explicitly opts-out of description, intended for situation when additional information is not needed for the user.
+`only-title: true` explicitly opts-out of description, intended for situation when additional information is not needed for the user.
 
 People refer to sections by their identifiers, not titles so that they don't accidentally duplicate the section just because of typo.
 Unknown sections in commit messages are rejected.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ the file now we check the metadata using file descriptor
 after opening the file. (before reading)
 
 changelog:
-    section: security:vuln_fixes
+    section: security.vuln_fixes
     title: Fix vulnerability related to opening files
     description: The application was vulnerable to attacks
                  if the attacker had access to the working

--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ Run `mkchlog help` for complete command options.
 
 ```yaml
 # .mkchlog.yml
-# OPTIONAL Commit number to start (same as -c 7c85bee4303d56bededdfacf8fbb7bdc68e2195b)
-skip-commits-up-to: 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
-
-# OPTIONAL Path to the git repository (same as -g ../git-mkchlog-test/)
-git-path: ../git-mkchlog-test/
-
 sections:
     # section identifier selected by project maintainer
     security:
@@ -59,6 +53,17 @@ sections:
     dev:
         title: Development
         description: Internal development changes
+
+# OPTIONAL Commit number to start (same as -c 7c85bee4303d56bededdfacf8fbb7bdc68e2195b)
+skip-commits-up-to: 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
+
+# OPTIONAL List of commit numbers to skip (in case you want to simply "revoke" some obsolete or wrong commit message from the changelog output)
+skip-commits-list:
+    - 12b6a464d165c18cc29394e332d6f6c6d09170e2
+    - a27c77b683c6334e79e94c232ed699f5a5216fee
+
+# OPTIONAL Path to the git repository (same as -g ../git-mkchlog-test/)
+git-path: ../git-mkchlog-test/
 ```
 
 #### Commits

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ projects:
     default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME [optional]
 ```
 
-If projects list is provided then git commit must contain `project: x` in the changelog message where `x` is one of the specified project names. After a project name the list of directories the project is contained in must be provided. Project `main` in the example above is the "root" project that contains all files in the project root directory plus other directories that do not belong to other projects.
+If projects list is provided then git commit must contain `project: x` in the changelog message where `x` is one of the specified project names. After a project name, the list of directories the project is contained in, must be provided. Project `main` in the example above is the "root" project that contains all files in the project root directory, plus other directories that do not belong to other projects.
 
 To help with migration additional `since-commit` and `default` keywords can be used together. If they are specified then commits up to `since-commit` are considered belonging to `default` project.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mkchlog
 
-Changelog generator tool suitable for user-facing changelogs and based on experiences of existing projects.
+Changelog generator tool suitable for user-facing changelogs and based on experiences of existing projects. More info on rationale is provided in the **Explanation** section below.
 
 ## Overview
 
@@ -36,7 +36,7 @@ Run `mkchlog help` for complete command options.
 #### Config file
 
 ```yaml
-# mkchlog.yml
+# .mkchlog.yml
 # OPTIONAL Commit number to start (same as -c 7c85bee4303d56bededdfacf8fbb7bdc68e2195b)
 skip-commits-up-to: 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 
@@ -179,17 +179,21 @@ Some repositories host multiple projects that are related but should have disjoi
 #### Config file
 
 ```yaml
-# mkchlog.yml
+# .mkchlog.yml
 # top level
 projects:
-    names: [mkchlog, mkchlog-action] # mandatory list of project names [mandatory]
+    list:  # list of allowed projects
+    - main: [".", .github, .githooks] # name: [directory1, directory2, ...]
+    - mkchlog: [mkchlog] # name: [directory]
+    - mkchlog-action: [mkchlog-action] # name: [directory]
+
     since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER [optional]
     default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME [optional]
 ```
 
-If projects `names` list is provided then git commit must contain `project: x` where `x` is one of the specified project names.
+If projects list is provided then git commit must contain `project: x` in the changelog message where `x` is one of the specified project names. After a project name the list of directories the project is contained in must be provided. Project `main` in the example above is the "root" project that contains all files in the project root directory plus other directories that do not belong to other projects.
 
-To help with migration additional `since-commit` and `default` keywords can be used together. if they are specified then commits up to `since-commit` are considered belonging to `default` project.
+To help with migration additional `since-commit` and `default` keywords can be used together. If they are specified then commits up to `since-commit` are considered belonging to `default` project.
 
 #### Commits
 
@@ -211,6 +215,14 @@ To generate changelog for the `mkchlog-action` project use the following command
 `mkchlog --project mkchlog-action gen`
 
 Run `mkchlog help` for complete command options.
+
+## Git Hooks
+
+To use locally configured githooks for the development you can run in the root directory of the repository:
+
+`git config --local core.hooksPath .githooks/`
+
+Alternatively add symlinks in your .git/hooks directory to any of the provided githooks.
 
 ## Explanation
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Internal development changes
 * Setup Github Actions
 ```
 
+[Detailed examples](EXAMPLES.md)
+
 ## Multi-project setup
 
 Some repositories host multiple projects that are related but should have disjoint changelogs. This is typical for multi-crate workspacess in Rust.

--- a/README.md
+++ b/README.md
@@ -267,3 +267,11 @@ Additionally, we don't want to depend on GitHub so that we can migrate easily if
 
 The minimal supported Rust version is 1.63 - Debian Bookworm.
 This also supports using the crates packaged in Debian - just delete `Cargo.lock` (which contains crates.io shasums of crates - some are slightly different in Debian).
+
+## Support
+
+If you find this tool useful and want to say "thank you" and support further development, you are welcome to send some satoshis to
+
+⚡ `capricorn@getalby.com` (LN adress, NOT an email address!)
+
+Every sat counts! Thank you.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ You can provide additional options:
 * Path to the git repository [default value is the current directory]. (This option can be also specified in `.mkchlog.yml`.)
 * `--from-stdin` Read commit(s) from stdin. Useful to use in a commit-msg git hook.
 
-
 `mkchlog -c 7c85bee4303d56bededdfacf8fbb7bdc68e2195b -f .mkchlog.yml -g ../git-mkchlog-test/ gen`
 
 Run `mkchlog help` for complete command options.
@@ -37,6 +36,7 @@ Run `mkchlog help` for complete command options.
 #### Config file
 
 ```yaml
+# mkchlog.yml
 # OPTIONAL Commit number to start (same as -c 7c85bee4303d56bededdfacf8fbb7bdc68e2195b)
 skip-commits-up-to: 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 
@@ -172,7 +172,47 @@ Internal development changes
 * Setup Github Actions
 ```
 
-### Explanation
+## Multi-project setup
+
+Some repositories host multiple projects that are related but should have disjoint changelogs. This is typical for multi-crate workspacess in Rust.
+
+#### Config file
+
+```yaml
+# mkchlog.yml
+# top level
+projects:
+    names: [mkchlog, mkchlog-action] # mandatory list of project names [mandatory]
+    since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER [optional]
+    default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME [optional]
+```
+
+If projects `names` list is provided then git commit must contain `project: x` where `x` is one of the specified project names.
+
+To help with migration additional `since-commit` and `default` keywords can be used together. if they are specified then commits up to `since-commit` are considered belonging to `default` project.
+
+#### Commits
+
+```
+Publish release version rather than debug
+
+This updates the wasm module to one which was compiled with `--release`.
+
+changelog:
+    project: mkchlog-action
+    section: perf
+    inherit: all
+```
+
+#### Usage
+
+To generate changelog for the `mkchlog-action` project use the following command:
+
+`mkchlog --project mkchlog-action gen`
+
+Run `mkchlog help` for complete command options.
+
+## Explanation
 
 (Rationale, idea and motivation by [Kixunil](https://github.com/Kixunil))
 
@@ -204,6 +244,8 @@ This is based on these experiences:
   CI complaining about missing information prevents forgetting.
 
 Additionally, we don't want to depend on GitHub so that we can migrate easily if needed - thus not pulling information from PRs.
+
+---
 
 ### MSRV
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -276,25 +276,30 @@ impl CommitChangelog {
             }
 
             let commit_message_description: String;
-            if title.is_empty() {
+            if title.is_empty() || description.is_empty() {
+                // get title and description from the commit message
                 let re = Regex::new(r"\n\s*\n").expect("should never panic"); // title is separated by an empty line
                 let mut commit_message_iter = re.splitn(&self.commit.message, 2);
 
-                title = commit_message_iter
+                let commit_message_title = commit_message_iter
                     .next()
                     .map(|s| s.trim())
                     .ok_or("Could not extract 'title' from commit message text")?;
 
-                if description.is_empty() {
-                    description = commit_message_iter
-                        .next()
-                        .map(|s| s.trim())
-                        .unwrap_or_default();
+                let commit_description = commit_message_iter
+                    .next()
+                    .map(|s| s.trim())
+                    .unwrap_or_default();
 
-                    // remove hard wrapping (linefeeds) and indentation added by git in the description
-                    let commit_message_description_lines: Vec<_> =
-                        description.lines().map(|s| s.trim()).collect();
-                    commit_message_description = commit_message_description_lines.join(" ");
+                // remove hard wrapping (linefeeds) and indentation added by git in the description
+                let commit_message_description_lines: Vec<_> =
+                    commit_description.lines().map(|s| s.trim()).collect();
+                commit_message_description = commit_message_description_lines.join(" ");
+
+                if title.is_empty() {
+                    title = commit_message_title;
+                }
+                if description.is_empty() {
                     description = &commit_message_description;
                 }
             }

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -246,7 +246,7 @@ impl CommitChangelog {
             self.commit.raw_data
         ))?;
         let (section, sub_section) = section
-            .split_once(':')
+            .split_once('.')
             .map(|(sec, subsec)| (sec.trim(), subsec.trim()))
             .unwrap_or((section, ""));
 
@@ -454,7 +454,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
     after opening the file. (before reading)
 
     changelog:
-        section: security:vuln_fixes
+        section: security.vuln_fixes
         title: Fixed vulnerability related to opening files
         description: The application was vulnerable to attacks
                     if the attacker had access to the working
@@ -464,7 +464,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                     unprivileged users you don't need to worry.";
 
         let exp = vec![
-                "section: security:vuln_fixes",
+                "section: security.vuln_fixes",
                 "title: Fixed vulnerability related to opening files",
                 "description: The application was vulnerable to attacks if the attacker had access to the working directory. If you run this in such enviroment you should update ASAP. If your working directory is **not** accessible by unprivileged users you don't need to worry."];
 
@@ -475,7 +475,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
         assert_eq!(*res, exp);
 
         let section = commit_changelog.get_key("section").unwrap();
-        assert_eq!(section, "security:vuln_fixes");
+        assert_eq!(section, "security.vuln_fixes");
 
         let title = commit_changelog.get_key("title").unwrap();
         assert_eq!(title, "Fixed vulnerability related to opening files");
@@ -500,7 +500,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
     Fixed TOCTOU race condition when opening file
 
     changelog:
-        section: security:vuln_fixes
+        section: security.vuln_fixes
         title: Fixed vulnerability related
         to opening files
         description: The application was vulnerable to attacks
@@ -511,7 +511,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                 unprivileged users you don't need to worry.";
 
         let exp = vec![
-                "section: security:vuln_fixes",
+                "section: security.vuln_fixes",
                 "title: Fixed vulnerability related to opening files",
                 "description: The application was vulnerable to attacks if the attacker had access to the working directory. If you run this in such enviroment you should update ASAP. If your working directory is **not** accessible by unprivileged users you don't need to worry."];
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Display;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 const FORCE_CHECK_ALL_PROJECTS: &str = "force_check_all_projects";
 
@@ -228,37 +228,6 @@ impl CommitChangelog {
                     changelog_project, self.commit.raw_data
                 )
                 .into());
-            }
-
-            if default_project.is_none() {
-                // default project is set only for commits that were created before projects were configured in the template file
-                // check if changed files belong to the project specified in changelog
-
-                if let Some(dirs) = allowed_projects.get(changelog_project) {
-                    // iterate through all directories belonging to the project
-                    for file in &self.commit.changed_files {
-                        let mut file_belongs_to_project = false;
-                        for dir in dirs {
-                            if dir == &PathBuf::from(".") && file.parent() == Some(Path::new("")) {
-                                // file is in main directory
-                                file_belongs_to_project = true;
-                                break;
-                            }
-                            if file.starts_with(dir) {
-                                // file is in subdirectory
-                                file_belongs_to_project = true;
-                                break;
-                            }
-                        }
-                        if !file_belongs_to_project {
-                            #[rustfmt::skip]
-                            return Err(format!("File: '{}' does not belong to project '{}' in commit:\n>>> {}",
-                                file.display(),
-                                changelog_project,
-                                self.commit.raw_data).into());
-                        }
-                    }
-                }
             }
 
             // return when commit belongs to different project than user asked for
@@ -492,12 +461,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                     directory. If you run this in such
                     enviroment you should update ASAP. If your
                     working directory is **not** accessible by
-                    unprivileged users you don't need to worry.
-
-src/bip324.cpp
-src/bip324.h
-src/crypto/chacha20poly1305.cpp
-src/crypto/chacha20poly1305.h";
+                    unprivileged users you don't need to worry.";
 
         let exp = vec![
                 "section: security:vuln_fixes",
@@ -544,12 +508,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                 directory. If you run this in such
                 enviroment you should update ASAP. If your
                 working directory is **not** accessible by
-                unprivileged users you don't need to worry.
-
-src/bip324.cpp
-src/bip324.h
-src/crypto/chacha20poly1305.cpp
-src/crypto/chacha20poly1305.h";
+                unprivileged users you don't need to worry.";
 
         let exp = vec![
                 "section: security:vuln_fixes",
@@ -574,9 +533,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
 
     changelog:
         inherit: all
-        section: features
-
-src/core_write.cpp";
+        section: features";
 
         let exp = vec!["inherit: all", "section: features"];
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,5 +1,7 @@
 //! Changelog creation logic
 
+mod parser;
+
 use crate::config::Command;
 use crate::git::commit::Commit;
 use crate::git::Git;
@@ -154,44 +156,12 @@ where
 /// Changelog information provided in the commit message
 struct CommitChangelog {
     commit: Commit,
-    changelog_lines: Vec<String>,
 }
 
 impl CommitChangelog {
     /// Creates a new [`CommitChangelog`] from the given [`Commit`].
     fn new(commit: Commit) -> Self {
-        let commit_changelog_lines = commit
-            .changelog_message
-            .lines()
-            .map(|s| s.trim())
-            .collect::<Vec<_>>();
-
-        let re = Regex::new(r"(?m)^[a-z-]+:").expect("should never panic"); // match keyword
-
-        let mut changelog_lines: Vec<String> = vec![];
-
-        for (i, &line) in commit_changelog_lines.iter().enumerate() {
-            if i == 0 {
-                changelog_lines.push(line.to_string());
-                continue;
-            }
-
-            if !re.is_match(line) {
-                // line does not start with keyword, append it to the previous one
-                // ie. remove hard wrapping (linefeeds) inside changelog section in commit message
-                let mut prev_line = changelog_lines.pop().unwrap_or_default();
-                prev_line.push(' ');
-                prev_line.push_str(line);
-                changelog_lines.push(prev_line);
-            } else {
-                changelog_lines.push(line.to_string());
-            }
-        }
-
-        Self {
-            commit,
-            changelog_lines,
-        }
+        Self { commit }
     }
 
     /// Parses changelog section from the commit and fills it in the provided [`ChangelogTemplate`]
@@ -205,7 +175,15 @@ impl CommitChangelog {
     where
         T: ChangesList + Default,
     {
-        if self.changelog_lines().len() == 1 && self.changelog_lines()[0] == "skip" {
+        // parse YAML changelog message
+        let changelog = parser::parse(&self.commit.changelog_message).map_err(|err| {
+            format!(
+                "{} in changelog message in commit:\n>>> {}",
+                err, self.commit.raw_data
+            )
+        })?;
+
+        if changelog.skip {
             return Ok(());
         }
 
@@ -213,145 +191,153 @@ impl CommitChangelog {
         if let Some(project) = project.as_deref() {
             // if default project is set, then act as if it was specified in commit's changelog message
             // otherwise get it from the changelog message
-            let changelog_project = if default_project.is_some() {
-                default_project.as_ref().expect("default project is set")
-            } else {
-                self.get_key("project").ok_or(format!(
-                    "Missing 'project' key in changelog message:\n>>> {}",
-                    self.commit.raw_data
-                ))?
-            };
+            let mut changelog_projects = vec![];
 
-            if !allowed_projects.contains(&changelog_project) {
-                return Err(format!(
-                    "Incorrect (not allowed in config file) project name '{}' in changelog message:\n>>> {}",
-                    changelog_project, self.commit.raw_data
-                )
-                .into());
+            if let Some(default_project) = default_project {
+                changelog_projects.push(default_project.as_str())
+            } else {
+                if changelog.projects.is_none() {
+                    // changelog message with one project
+                    let project = changelog.project.as_ref().ok_or(format!(
+                        "Missing 'project' key in changelog message:\n>>> {}",
+                        self.commit.raw_data
+                    ))?;
+                    changelog_projects.push(project.as_str());
+                } else {
+                    // changelog message with sequence of projects
+                    let projects = changelog
+                        .projects
+                        .as_ref()
+                        .expect("projects cannot be empty");
+
+                    changelog_projects = projects.iter().map(|p| p.name.as_str()).collect();
+                }
+
+                for proj_name in changelog_projects.iter() {
+                    if !allowed_projects.contains(proj_name) {
+                        return Err(format!("Incorrect (not allowed in config file) project name '{}' in changelog message:\n>>> {}",
+                            proj_name, self.commit.raw_data).into());
+                    }
+                }
             }
 
-            // return when commit belongs to different project than user asked for
-            if changelog_project != project && project != FORCE_CHECK_ALL_PROJECTS {
+            // return when commit belongs to different project than user asked for (and we are not checking everything)
+            if !changelog_projects.contains(&project) && project != FORCE_CHECK_ALL_PROJECTS {
                 return Ok(());
             }
         }
 
-        let mut title = self.get_key("title").unwrap_or("");
-        let mut description = self.get_key("description").unwrap_or("");
-        let title_is_enough = self.get_key("title-is-enough").unwrap_or("");
-        let inherit = self.get_key("inherit").unwrap_or("");
+        let mut changelogs = vec![changelog.clone()]; // changelog of one project or changelogs of more projects in one commit
 
-        let section = self.get_key("section").ok_or(format!(
-            "Missing 'section' key in changelog message:\n>>> {}",
-            self.commit.raw_data
-        ))?;
-        let (section, sub_section) = section
-            .split_once('.')
-            .map(|(sec, subsec)| (sec.trim(), subsec.trim()))
-            .unwrap_or((section, ""));
+        if changelog.projects.is_some() {
+            // changelog message with sequence of projects
+            changelogs = changelog
+                .projects
+                .expect("projects are not empty")
+                .into_iter()
+                .map(|p| p.into())
+                .collect::<Vec<parser::Changelog>>();
+        }
 
-        if !changelog_template.contains_key(section) {
-            if section.is_empty() {
+        for changelog in changelogs.iter() {
+            if changelog.skip {
+                continue;
+            }
+
+            if let Some(changelog_project) = changelog.project.as_ref() {
+                if let Some(project) = project {
+                    if changelog_project != project && project != FORCE_CHECK_ALL_PROJECTS {
+                        continue; // commit belongs to a different project and we are not checking them all
+                    }
+                }
+            }
+
+            let mut title = changelog.title.as_deref().unwrap_or("");
+            let mut description = changelog.description.as_deref().unwrap_or("");
+            let title_is_enough = changelog.title_is_enough;
+            let inherit = changelog.inherit.as_deref().unwrap_or("");
+
+            let section = changelog.section.as_str();
+            let (section, sub_section) = section
+                .split_once('.')
+                .map(|(sec, subsec)| (sec.trim(), subsec.trim()))
+                .unwrap_or((section, ""));
+
+            if !changelog_template.contains_key(section) {
                 return Err(format!(
-                    "Empty section in changelog message:\n>>> {}",
-                    self.commit.raw_data
+                    "Unknown section '{}' in changelog message in commit:\n>>> {}",
+                    section, self.commit.raw_data
                 )
                 .into());
             }
 
-            return Err(format!(
-                "Unknown section '{}' in changelog message:\n>>> {}",
-                section, self.commit.raw_data
-            )
-            .into());
-        }
+            let commit_message_description: String;
+            if inherit == "all" || inherit == "title" || (title_is_enough && title.is_empty()) {
+                let re = Regex::new(r"\n\s*\n").expect("should never panic"); // title is separated by an empty line
+                let mut commit_message_iter = re.splitn(&self.commit.message, 2);
 
-        let commit_message_description: String;
-        if inherit == "all"
-            || inherit == "title"
-            || (!title_is_enough.is_empty() && title.is_empty())
-        {
-            let re = Regex::new(r"\n\s*\n").expect("should never panic"); // title is separated by an empty line
-            let mut commit_message_iter = re.splitn(&self.commit.message, 2);
-
-            title = commit_message_iter
-                .next()
-                .map(|s| s.trim())
-                .ok_or("Could not extract 'title' from commit message text")?;
-
-            if description.is_empty() {
-                description = commit_message_iter
+                title = commit_message_iter
                     .next()
                     .map(|s| s.trim())
-                    .unwrap_or_default();
+                    .ok_or("Could not extract 'title' from commit message text")?;
 
-                // remove hard wrapping (linefeeds) and indentation added by git in the description
-                let commit_message_description_lines: Vec<_> =
-                    description.lines().map(|s| s.trim()).collect();
-                commit_message_description = commit_message_description_lines.join(" ");
-                description = &commit_message_description;
+                if description.is_empty() {
+                    description = commit_message_iter
+                        .next()
+                        .map(|s| s.trim())
+                        .unwrap_or_default();
+
+                    // remove hard wrapping (linefeeds) and indentation added by git in the description
+                    let commit_message_description_lines: Vec<_> =
+                        description.lines().map(|s| s.trim()).collect();
+                    commit_message_description = commit_message_description_lines.join(" ");
+                    description = &commit_message_description;
+                }
             }
-        }
 
-        // we have title and description, we can insert them to changelog_template
-        let title_prefix: &str;
-        let mut change_type = ChangeType::Other;
-        let mut change = String::new();
+            // we have title and description, we can insert them to changelog_template
+            let title_prefix: &str;
+            let mut change_type = ChangeType::Other;
+            let mut change = String::new();
 
-        if !title.is_empty() {
-            if !title_is_enough.is_empty() || description.is_empty() {
-                change_type = ChangeType::TitleOnly;
-                title_prefix = "* ";
-            } else if !sub_section.is_empty() {
-                title_prefix = "#### ";
+            if !title.is_empty() {
+                if title_is_enough || description.is_empty() {
+                    change_type = ChangeType::TitleOnly;
+                    title_prefix = "* ";
+                } else if !sub_section.is_empty() {
+                    title_prefix = "#### ";
+                } else {
+                    title_prefix = "### ";
+                }
+                change = title_prefix.to_owned();
+                change.push_str(title);
+                change.push_str("\n\n");
+            }
+
+            if !description.is_empty() && !title_is_enough {
+                change.push_str(description);
+                change.push_str("\n\n");
+            }
+
+            if !sub_section.is_empty() {
+                changelog_template
+                    .get_mut(section)
+                    .expect("section should be set correctly")
+                    .subsections
+                    .get_mut(sub_section)
+                    .expect("sub_section is not empty here")
+                    .changes
+                    .add(change_type, change);
             } else {
-                title_prefix = "### ";
+                changelog_template
+                    .get_mut(section)
+                    .expect("section should be set correctly")
+                    .changes
+                    .add(change_type, change);
             }
-            change = title_prefix.to_owned();
-            change.push_str(title);
-            change.push_str("\n\n");
-        }
-
-        if !description.is_empty() && title_is_enough.is_empty() {
-            change.push_str(description);
-            change.push_str("\n\n");
-        }
-
-        if !sub_section.is_empty() {
-            changelog_template
-                .get_mut(section)
-                .expect("section should be set correctly")
-                .subsections
-                .get_mut(sub_section)
-                .expect("sub_section is not empty here")
-                .changes
-                .add(change_type, change);
-        } else {
-            changelog_template
-                .get_mut(section)
-                .expect("section should be set correctly")
-                .changes
-                .add(change_type, change);
         }
 
         Ok(())
-    }
-
-    /// Retuns the key from the changelog section in the commit
-    fn get_key(&self, key: &str) -> Option<&str> {
-        let key = key.to_owned() + ":";
-        self.changelog_lines
-            .iter()
-            .map(|s| s.as_str())
-            .find(|&line| line.starts_with(&key))
-            .unwrap_or("")
-            .split_once(':')
-            .map(|(_, s)| s.trim())
-    }
-
-    // Return parsed lines from changelog section in the commit message
-    fn changelog_lines(&self) -> &Vec<String> {
-        self.changelog_lines.as_ref()
     }
 }
 
@@ -433,114 +419,5 @@ impl fmt::Display for Changes {
         result.push_str(&other);
 
         write!(f, "{}", result)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn commit_changelog_with_multiple_lines_in_description() {
-        let raw_data = "\
-commit 1cc72956df91e2fd8c45e72983c4e1149f1ac3b3
-Author: Cry Wolf <cry.wolf@centrum.cz>
-Date:   Tue Jun 13 16:27:59 2023 +0200
-
-    Fixed TOCTOU race condition when opening file
-
-    Previously we checked the file permissions before opening
-    the file now we check the metadata using file descriptor
-    after opening the file. (before reading)
-
-    changelog:
-        section: security.vuln_fixes
-        title: Fixed vulnerability related to opening files
-        description: The application was vulnerable to attacks
-                    if the attacker had access to the working
-                    directory. If you run this in such
-                    enviroment you should update ASAP. If your
-                    working directory is **not** accessible by
-                    unprivileged users you don't need to worry.";
-
-        let exp = vec![
-                "section: security.vuln_fixes",
-                "title: Fixed vulnerability related to opening files",
-                "description: The application was vulnerable to attacks if the attacker had access to the working directory. If you run this in such enviroment you should update ASAP. If your working directory is **not** accessible by unprivileged users you don't need to worry."];
-
-        let commit = Commit::new(raw_data).unwrap();
-        let commit_changelog = CommitChangelog::new(commit);
-        let res = commit_changelog.changelog_lines();
-        assert_eq!(res.len(), 3);
-        assert_eq!(*res, exp);
-
-        let section = commit_changelog.get_key("section").unwrap();
-        assert_eq!(section, "security.vuln_fixes");
-
-        let title = commit_changelog.get_key("title").unwrap();
-        assert_eq!(title, "Fixed vulnerability related to opening files");
-
-        // should not find non-present key ("descr" is not present, "description" is)
-        assert!(
-            commit_changelog.get_key("descr").is_none(),
-            "should not find non-present key"
-        );
-
-        let descr = commit_changelog.get_key("description").unwrap();
-        assert_eq!(descr, "The application was vulnerable to attacks if the attacker had access to the working directory. If you run this in such enviroment you should update ASAP. If your working directory is **not** accessible by unprivileged users you don't need to worry.");
-    }
-
-    #[test]
-    fn commit_changelog_with_multiple_lines_in_title_and_description() {
-        let raw_data = "\
-commit 1cc72956df91e2fd8c45e72983c4e1149f1ac3b3
-Author: Cry Wolf <cry.wolf@centrum.cz>
-Date:   Tue Jun 13 16:27:59 2023 +0200
-
-    Fixed TOCTOU race condition when opening file
-
-    changelog:
-        section: security.vuln_fixes
-        title: Fixed vulnerability related
-        to opening files
-        description: The application was vulnerable to attacks
-                if the attacker had access to the working
-                directory. If you run this in such
-                enviroment you should update ASAP. If your
-                working directory is **not** accessible by
-                unprivileged users you don't need to worry.";
-
-        let exp = vec![
-                "section: security.vuln_fixes",
-                "title: Fixed vulnerability related to opening files",
-                "description: The application was vulnerable to attacks if the attacker had access to the working directory. If you run this in such enviroment you should update ASAP. If your working directory is **not** accessible by unprivileged users you don't need to worry."];
-
-        let commit = Commit::new(raw_data).unwrap();
-        let commit_changelog = CommitChangelog::new(commit);
-        let res = commit_changelog.changelog_lines();
-        assert_eq!(res.len(), 3);
-        assert_eq!(*res, exp);
-    }
-
-    #[test]
-    fn commit_changelog_without_multiple_lines() {
-        let raw_data = "\
-commit 1cc72956df91e2fd8c45e72983c4e1149f1ac3b3
-Author: Cry Wolf <cry.wolf@centrum.cz>
-Date:   Tue Jun 13 16:27:59 2023 +0200
-
-    Some feature
-
-    changelog:
-        inherit: all
-        section: features";
-
-        let exp = vec!["inherit: all", "section: features"];
-
-        let commit = Commit::new(raw_data).unwrap();
-        let commit_changelog = CommitChangelog::new(commit);
-        let res = commit_changelog.changelog_lines();
-        assert_eq!(res.len(), 2);
-        assert_eq!(*res, exp);
     }
 }

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -255,7 +255,6 @@ impl CommitChangelog {
             let mut title = changelog.title.as_deref().unwrap_or("");
             let mut description = changelog.description.as_deref().unwrap_or("");
             let title_is_enough = changelog.title_is_enough;
-            let inherit = changelog.inherit.as_deref().unwrap_or("");
 
             let section = changelog.section.as_str();
             let (section, sub_section) = section
@@ -272,7 +271,7 @@ impl CommitChangelog {
             }
 
             let commit_message_description: String;
-            if inherit == "all" || inherit == "title" || (title_is_enough && title.is_empty()) {
+            if title.is_empty() {
                 let re = Regex::new(r"\n\s*\n").expect("should never panic"); // title is separated by an empty line
                 let mut commit_message_iter = re.splitn(&self.commit.message, 2);
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -45,6 +45,7 @@ where
             .since_commit
             .clone()
             .unwrap_or_default();
+        let skip_commits_list = settings.skip_commits_list.clone();
 
         let use_default_project = default_project_from_config.is_some();
         let mut default_project = &None;
@@ -72,6 +73,10 @@ where
 
         // iterate through commits and fill in the changelog_template
         for commit in commits {
+            if skip_commits_list.contains(&commit.commit_id) {
+                continue;
+            }
+
             // all commit until `since-commit` should belong to `default_project`
             if use_default_project {
                 if set_default_project {

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -254,7 +254,7 @@ impl CommitChangelog {
 
             let mut title = changelog.title.as_deref().unwrap_or("");
             let mut description = changelog.description.as_deref().unwrap_or("");
-            let title_is_enough = changelog.title_is_enough;
+            let only_title = changelog.only_title;
 
             let section = changelog.section.as_str();
             let (section, sub_section) = section
@@ -300,7 +300,7 @@ impl CommitChangelog {
             let mut change = String::new();
 
             if !title.is_empty() {
-                if title_is_enough || description.is_empty() {
+                if only_title || description.is_empty() {
                     change_type = ChangeType::TitleOnly;
                     title_prefix = "* ";
                 } else if !sub_section.is_empty() {
@@ -313,7 +313,7 @@ impl CommitChangelog {
                 change.push_str("\n\n");
             }
 
-            if !description.is_empty() && !title_is_enough {
+            if !description.is_empty() && !only_title {
                 change.push_str(description);
                 change.push_str("\n\n");
             }

--- a/src/changelog/parser.rs
+++ b/src/changelog/parser.rs
@@ -32,7 +32,8 @@ pub struct Changelog {
     #[serde(rename = "title-is-enough", default)]
     pub title_is_enough: bool,
     pub description: Option<String>,
-    pub inherit: Option<String>,
+    pub inherit: Option<String>, // ignored, only for backwards compatibility
+    #[serde(skip)]
     pub projects: Option<Vec<Project>>,
 }
 
@@ -53,7 +54,6 @@ pub struct Project {
     #[serde(rename = "title-is-enough", default)]
     pub title_is_enough: bool,
     pub description: Option<String>,
-    pub inherit: Option<String>,
 }
 
 impl From<Project> for Changelog {
@@ -65,7 +65,7 @@ impl From<Project> for Changelog {
             title: project.title,
             title_is_enough: project.title_is_enough,
             description: project.description,
-            inherit: project.inherit,
+            inherit: None,
             projects: None,
         }
     }
@@ -183,7 +183,6 @@ mod tests {
         let yaml = "
         project: mkchlog-action
         section: doc
-        inherit: title
         title-is-enough: true";
 
         let expected = Changelog {
@@ -193,7 +192,7 @@ mod tests {
             title: None,
             title_is_enough: true,
             description: None,
-            inherit: Some("title".to_owned()),
+            inherit: None,
             projects: None,
         };
 
@@ -202,7 +201,6 @@ mod tests {
 
         let yaml = "
         section: features
-        inherit: all
         project: mkchlog";
 
         let expected = Changelog {
@@ -212,7 +210,7 @@ mod tests {
             title: None,
             title_is_enough: false,
             description: None,
-            inherit: Some("all".to_owned()),
+            inherit: None,
             projects: None,
         };
 
@@ -221,7 +219,6 @@ mod tests {
 
         let yaml = "
         section: features
-        inherit: all
         project: ";
 
         let expected = Changelog {
@@ -231,7 +228,7 @@ mod tests {
             title: None,
             title_is_enough: false,
             description: None,
-            inherit: Some("all".to_owned()),
+            inherit: None,
             projects: None,
         };
 
@@ -267,7 +264,6 @@ mod tests {
             .starts_with("changelog: unknown field `nonsense`"));
 
         let yaml = "
-        inherit: all
         project: mkchlog";
 
         let res = parse(yaml);
@@ -279,8 +275,7 @@ mod tests {
             .starts_with("changelog: missing field `section`"));
 
         let yaml = "
-        section:
-        inherit: all";
+        section:";
 
         let res = parse(yaml).unwrap();
 
@@ -293,7 +288,6 @@ mod tests {
         - project:
            name: mkchlog
            section: dev
-           inherit: title
            title-is-enough: true
         - project:
            name: mkchlog-action
@@ -315,7 +309,6 @@ mod tests {
                     title: None,
                     title_is_enough: true,
                     description: None,
-                    inherit: Some("title".to_owned()),
                 },
                 Project {
                     skip: true,
@@ -324,7 +317,6 @@ mod tests {
                     title: None,
                     title_is_enough: false,
                     description: None,
-                    inherit: None,
                 },
             ]),
         };

--- a/src/changelog/parser.rs
+++ b/src/changelog/parser.rs
@@ -1,0 +1,335 @@
+//! YAML parser
+
+use serde::de::{self, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+use serde_yaml::Error;
+use std::fmt;
+use std::marker::PhantomData;
+use std::str::FromStr;
+
+/// Parse the content of a changelog message into a [`Changelog`] structure
+pub fn parse(s: &str) -> Result<Changelog, Error> {
+    let s = &format!("changelog:{}", s);
+    let chw = serde_yaml::from_str::<ChangelogWrapper>(s)?;
+    Ok(chw.changelog)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChangelogWrapper {
+    #[serde(deserialize_with = "string_or_struct_or_vec")]
+    changelog: Changelog,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Changelog {
+    #[serde(default)]
+    pub skip: bool,
+    pub project: Option<String>,
+    pub section: String,
+    pub title: Option<String>,
+    #[serde(rename = "title-is-enough", default)]
+    pub title_is_enough: bool,
+    pub description: Option<String>,
+    pub inherit: Option<String>,
+    pub projects: Option<Vec<Project>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct ProjectWrapper {
+    pub project: Project,
+}
+
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Project {
+    #[serde(default)]
+    pub skip: bool,
+    pub name: String,
+    pub section: Option<String>,
+    pub title: Option<String>,
+    #[serde(rename = "title-is-enough", default)]
+    pub title_is_enough: bool,
+    pub description: Option<String>,
+    pub inherit: Option<String>,
+}
+
+impl From<Project> for Changelog {
+    fn from(project: Project) -> Self {
+        Changelog {
+            skip: project.skip,
+            project: Some(project.name),
+            section: project.section.unwrap_or_default(),
+            title: project.title,
+            title_is_enough: project.title_is_enough,
+            description: project.description,
+            inherit: project.inherit,
+            projects: None,
+        }
+    }
+}
+
+impl From<Vec<Project>> for Changelog {
+    fn from(projects: Vec<Project>) -> Self {
+        Changelog {
+            projects: Some(projects),
+            ..Default::default()
+        }
+    }
+}
+
+impl FromStr for Changelog {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.trim() != "skip" {
+            return Err(de::Error::custom(format!("Unexpected value '{}'", s)));
+        }
+
+        let chlg = Changelog {
+            skip: true,
+            ..Default::default()
+        };
+
+        Ok(chlg)
+    }
+}
+
+// T type can be deserialized either from a string, map or sequence of maps
+fn string_or_struct_or_vec<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Deserialize<'de> + FromStr<Err = Error> + From<Vec<Project>>,
+    D: Deserializer<'de>,
+{
+    // This is a Visitor that forwards string types to T's `FromStr` impl and
+    // forwards map types to T's `Deserialize` impl. The `PhantomData` is to
+    // keep the compiler from complaining about T being an unused generic type
+    // parameter. We need T in order to know the Value type for the Visitor
+    // impl.
+    struct StringOrStructOrVec<T>(PhantomData<fn() -> T>);
+
+    impl<'de, T> Visitor<'de> for StringOrStructOrVec<T>
+    where
+        T: Deserialize<'de> + FromStr<Err = Error> + From<Vec<Project>>,
+    {
+        type Value = T;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or map or sequence")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<T, E>
+        where
+            E: de::Error,
+        {
+            T::from_str(value).map_err(|err| de::Error::custom(err.to_string()))
+        }
+
+        fn visit_map<M>(self, map: M) -> Result<T, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            // `MapAccessDeserializer` is a wrapper that turns a `MapAccess`
+            // into a `Deserializer`, allowing it to be used as the input to T's
+            // `Deserialize` implementation. T then deserializes itself using
+            // the entries from the map visitor.
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+
+        fn visit_seq<S>(self, mut seq: S) -> Result<T, S::Error>
+        where
+            S: SeqAccess<'de>,
+        {
+            // Convert the deserialized sequence of ProjectWrappers into a Changelog instance
+            let mut projects = Vec::<Project>::new();
+            while let Some(pw) = seq.next_element::<ProjectWrapper>()? {
+                projects.push(pw.project);
+            }
+
+            Ok(projects.into())
+        }
+    }
+
+    deserializer.deserialize_any(StringOrStructOrVec(PhantomData))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_changelog_yaml_skip() {
+        let yaml = " skip";
+
+        let expected = Changelog {
+            skip: true,
+            project: None,
+            section: "".to_owned(),
+            title: None,
+            title_is_enough: false,
+            description: None,
+            inherit: None,
+            projects: None,
+        };
+
+        let res = parse(yaml).unwrap();
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn parse_changelog_yaml_map() {
+        let yaml = "
+        project: mkchlog-action
+        section: doc
+        inherit: title
+        title-is-enough: true";
+
+        let expected = Changelog {
+            skip: false,
+            project: Some("mkchlog-action".to_owned()),
+            section: "doc".to_owned(),
+            title: None,
+            title_is_enough: true,
+            description: None,
+            inherit: Some("title".to_owned()),
+            projects: None,
+        };
+
+        let res = parse(yaml).unwrap();
+        assert_eq!(res, expected);
+
+        let yaml = "
+        section: features
+        inherit: all
+        project: mkchlog";
+
+        let expected = Changelog {
+            skip: false,
+            project: Some("mkchlog".to_owned()),
+            section: "features".to_owned(),
+            title: None,
+            title_is_enough: false,
+            description: None,
+            inherit: Some("all".to_owned()),
+            projects: None,
+        };
+
+        let res = parse(yaml).unwrap();
+        assert_eq!(res, expected);
+
+        let yaml = "
+        section: features
+        inherit: all
+        project: ";
+
+        let expected = Changelog {
+            skip: false,
+            project: None,
+            section: "features".to_owned(),
+            title: None,
+            title_is_enough: false,
+            description: None,
+            inherit: Some("all".to_owned()),
+            projects: None,
+        };
+
+        let res = parse(yaml).unwrap();
+        assert_eq!(res, expected);
+
+        let yaml = "
+        section: features";
+
+        let expected = Changelog {
+            skip: false,
+            project: None,
+            section: "features".to_owned(),
+            title: None,
+            title_is_enough: false,
+            description: None,
+            inherit: None,
+            projects: None,
+        };
+
+        let res = parse(yaml).unwrap();
+        assert_eq!(res, expected);
+
+        let yaml = "
+        section: features
+        nonsense: yes";
+
+        let res = parse(yaml);
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .starts_with("changelog: unknown field `nonsense`"));
+
+        let yaml = "
+        inherit: all
+        project: mkchlog";
+
+        let res = parse(yaml);
+        assert!(res.is_err());
+
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .starts_with("changelog: missing field `section`"));
+
+        let yaml = "
+        section:
+        inherit: all";
+
+        let res = parse(yaml).unwrap();
+
+        assert_eq!(res.section, "~");
+    }
+
+    #[test]
+    fn parse_changelog_yaml_list() {
+        let yaml = "
+        - project:
+           name: mkchlog
+           section: dev
+           inherit: title
+           title-is-enough: true
+        - project:
+           name: mkchlog-action
+           skip: true";
+
+        let expected = Changelog {
+            skip: false,
+            project: None,
+            section: "".to_owned(),
+            title: None,
+            title_is_enough: false,
+            description: None,
+            inherit: None,
+            projects: Some(vec![
+                Project {
+                    skip: false,
+                    name: "mkchlog".to_owned(),
+                    section: Some("dev".to_owned()),
+                    title: None,
+                    title_is_enough: true,
+                    description: None,
+                    inherit: Some("title".to_owned()),
+                },
+                Project {
+                    skip: true,
+                    name: "mkchlog-action".to_owned(),
+                    section: None,
+                    title: None,
+                    title_is_enough: false,
+                    description: None,
+                    inherit: None,
+                },
+            ]),
+        };
+
+        let res = parse(yaml).unwrap();
+        assert_eq!(res, expected);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub struct Config {
     pub commit_id: Option<String>,
     /// Name of the project in multi-project repository for which we want to generate changelog.
     pub project: Option<String>,
-    /// Read commit(s) from stdin
+    /// Read commit from stdin
     pub read_from_stdin: bool,
 }
 
@@ -57,7 +57,7 @@ struct Args {
     #[arg(short, long)]
     git_path: Option<PathBuf>,
 
-    /// Read commit(s) from stdin
+    /// Read commit from stdin (useful for git hook)
     #[arg(long, default_value_t = false)]
     from_stdin: bool,
 
@@ -70,7 +70,10 @@ struct Args {
 pub enum Command {
     /// Verify the structure of commit messages
     Check,
-    /// Process git history and output the changelog in markdown format
+    /// Process and verify git history and print the changelog in markdown format
     #[command(name = "gen")]
     Generate,
+    /// Read commit from stdin and print commit template for git hook
+    #[command(name = "commit-template")]
+    CommitTemplate,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,7 +66,7 @@ struct Args {
 }
 
 /// Application commands
-#[derive(Subcommand)]
+#[derive(Subcommand, PartialEq)]
 pub enum Command {
     /// Verify the structure of commit messages
     Check,

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub git_path: Option<std::path::PathBuf>,
     /// Commit number to start. This one and previous commits will be skipped during processing.
     pub commit_id: Option<String>,
+    /// Name of the project in multi-project repository for which we want to generate changelog.
+    pub project: Option<String>,
     /// Read commit(s) from stdin
     pub read_from_stdin: bool,
 }
@@ -29,6 +31,7 @@ impl Config {
             file_path: args.file_path.unwrap_or(PathBuf::from(".mkchlog.yml")),
             git_path: args.git_path,
             commit_id: args.commit,
+            project: args.project,
             read_from_stdin: args.from_stdin,
         })
     }
@@ -38,6 +41,14 @@ impl Config {
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 struct Args {
+    /// Name of the project in multi-project repository for which we want to generate changelog.
+    #[arg(short, long)]
+    project: Option<String>,
+
+    /// Optional commit number. This one and previous commits will be skipped. By default, all commit messages are checked.
+    #[arg(short, long)]
+    commit: Option<String>,
+
     /// Optional path to the YAML template file [default: ".mkchlog.yml"]
     #[arg(short, long)]
     file_path: Option<PathBuf>,
@@ -45,10 +56,6 @@ struct Args {
     /// Optional path to the git repository (path to the .git directory) [default: "./"]
     #[arg(short, long)]
     git_path: Option<PathBuf>,
-
-    /// Optional commit number. This one and previous commits will be skipped. By default, all commit messages are checked.
-    #[arg(short, long)]
-    commit: Option<String>,
 
     /// Read commit(s) from stdin
     #[arg(long, default_value_t = false)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -71,9 +71,6 @@ Date:   Tue Jun 13 16:25:29 2023 +0200
 
     changelog: skip
 
-README.md
-src/template.rs
-
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -86,9 +83,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features
-
-src/lib.rs";
+        section: features";
 
             Ok(ouput.to_string())
         }

--- a/src/git.rs
+++ b/src/git.rs
@@ -32,6 +32,10 @@ impl Git {
         // however for some unknown reason it would cause `npm` to silently exit with success code when ran in WASM.
         // This workarounds the issue.
         let mut commits = Vec::new();
+        if git_log.is_empty() {
+            return Ok(commits);
+        }
+
         let mut pos = 0;
         loop {
             let end = git_log[(pos + 1)..].find("\ncommit ");
@@ -82,7 +86,6 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        inherit: all
         section: features";
 
             Ok(ouput.to_string())

--- a/src/git.rs
+++ b/src/git.rs
@@ -71,6 +71,9 @@ Date:   Tue Jun 13 16:25:29 2023 +0200
 
     changelog: skip
 
+README.md
+src/template.rs
+
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -83,7 +86,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features";
+        section: features
+
+src/lib.rs";
 
             Ok(ouput.to_string())
         }

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -23,7 +23,9 @@ impl super::GitLogCommand for GitLogCmd {
             .arg("-C")
             .arg(&self.path)
             .arg("log")
-            .arg("--no-merges");
+            .arg("--no-merges")
+            .arg("--stat")
+            .arg("--name-only");
 
         if self.commit_id.is_some() {
             // add argument: git log 7c85bee4303d56bededdfacf8fbb7bdc68e2195b..HEAD

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -23,9 +23,7 @@ impl super::GitLogCommand for GitLogCmd {
             .arg("-C")
             .arg(&self.path)
             .arg("log")
-            .arg("--no-merges")
-            .arg("--stat")
-            .arg("--name-only");
+            .arg("--no-merges");
 
         if self.commit_id.is_some() {
             // add argument: git log 7c85bee4303d56bededdfacf8fbb7bdc68e2195b..HEAD

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -1,7 +1,7 @@
 //! Git commit
 
 use regex::Regex;
-use std::{error::Error, path::PathBuf};
+use std::error::Error;
 
 /// Git commit
 #[derive(Debug)]
@@ -16,8 +16,6 @@ pub struct Commit {
     pub changelog_message: String,
     /// Raw data of the commit
     pub raw_data: String,
-    /// Files changed by the commit
-    pub changed_files: Vec<std::path::PathBuf>,
 }
 
 impl Commit {
@@ -41,20 +39,10 @@ impl Commit {
                 raw_data
             ))?;
 
-        let (changelog, changed_files) = commit_iter
-            .next()
-            .map(str::trim)
-            .ok_or(format!(
-                "Missing 'changelog:' key in commit:\n>>> {}",
-                raw_data
-            ))?
-            .rsplit_once("\n\n")
-            .ok_or(format!(
-                "Could not extract changed files from commit:\n>>> {}",
-                raw_data
-            ))?;
-
-        let changed_files: Vec<PathBuf> = Vec::from_iter(changed_files.lines().map(PathBuf::from));
+        let changelog = commit_iter.next().map(str::trim).ok_or(format!(
+            "Missing 'changelog:' key in commit:\n>>> {}",
+            raw_data
+        ))?;
 
         let commit_id = header
             .lines()
@@ -75,7 +63,6 @@ impl Commit {
             message: commit_message.trim().to_owned(),
             changelog_message: changelog.to_owned(),
             raw_data: raw_data.to_owned(),
-            changed_files,
         };
 
         Ok(commit)
@@ -85,7 +72,6 @@ impl Commit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[test]
     fn commit_new() {
@@ -101,14 +87,7 @@ Date:   Tue Jun 13 16:26:35 2023 +0200
     changelog:
         section: perf
         title: Improved processing speed by 10%
-        title-is-enough: true
-
-.githooks/commit-msg
-README.md
-src/config.rs
-src/template.rs
-tests/integration_test.rs
-";
+        title-is-enough: true";
 
         let exp_header = "commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -123,25 +102,16 @@ Date:   Tue Jun 13 16:26:35 2023 +0200";
         title: Improved processing speed by 10%
         title-is-enough: true";
 
-        let exp_changed_files = vec![
-            PathBuf::from(".githooks/commit-msg"),
-            PathBuf::from("README.md"),
-            PathBuf::from("src/config.rs"),
-            PathBuf::from("src/template.rs"),
-            PathBuf::from("tests/integration_test.rs"),
-        ];
-
         let res = Commit::new(raw_data).unwrap();
         assert_eq!(res.header, exp_header);
         assert_eq!(res.message, exp_message);
         assert_eq!(res.changelog_message, exp_changelog_message);
-        assert_eq!(res.changed_files, exp_changed_files);
     }
 
     #[test]
     fn commit_new_with_windows_extra_carrige_return() {
         // commit with \r\n as a line separator
-        let raw_data = "commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b\r\nAuthor: Cry Wolf <cry.wolf@centrum.cz>\r\nDate:   Tue Jun 13 16:26:35 2023 +0200\r\n\r\n    Don't reallocate the buffer when we know its size\r\n    changelog:\r\n        section: perf\r\n        title: Improved processing speed by 10%\r\n        title-is-enough: true\r\n\r\nsrc/something.txt";
+        let raw_data = "commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b\r\nAuthor: Cry Wolf <cry.wolf@centrum.cz>\r\nDate:   Tue Jun 13 16:26:35 2023 +0200\r\n\r\n    Don't reallocate the buffer when we know its size\r\n    changelog:\r\n        section: perf\r\n        title: Improved processing speed by 10%\r\n        title-is-enough: true";
 
         let exp_header = "commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -153,13 +123,10 @@ Date:   Tue Jun 13 16:26:35 2023 +0200";
         title: Improved processing speed by 10%
         title-is-enough: true";
 
-        let exp_changed_files = vec![PathBuf::from("src/something.txt")];
-
         let res = Commit::new(raw_data).unwrap();
         assert_eq!(res.header, exp_header);
         assert_eq!(res.message, exp_message);
         assert_eq!(res.changelog_message, exp_changelog_message);
-        assert_eq!(res.changed_files, exp_changed_files);
     }
 
     #[test]

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -87,7 +87,7 @@ Date:   Tue Jun 13 16:26:35 2023 +0200
     changelog:
         section: perf
         title: Improved processing speed by 10%
-        title-is-enough: true";
+        only-title: true";
 
         let exp_header = "commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -101,7 +101,7 @@ Date:   Tue Jun 13 16:26:35 2023 +0200";
         let exp_changelog_message = "
         section: perf
         title: Improved processing speed by 10%
-        title-is-enough: true";
+        only-title: true";
 
         let res = Commit::new(raw_data).unwrap();
         assert_eq!(res.header, exp_header);
@@ -112,7 +112,7 @@ Date:   Tue Jun 13 16:26:35 2023 +0200";
     #[test]
     fn commit_new_with_windows_extra_carrige_return() {
         // commit with \r\n as a line separator
-        let raw_data = "commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b\r\nAuthor: Cry Wolf <cry.wolf@centrum.cz>\r\nDate:   Tue Jun 13 16:26:35 2023 +0200\r\n\r\n    Don't reallocate the buffer when we know its size\r\n    changelog:\r\n        section: perf\r\n        title: Improved processing speed by 10%\r\n        title-is-enough: true";
+        let raw_data = "commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b\r\nAuthor: Cry Wolf <cry.wolf@centrum.cz>\r\nDate:   Tue Jun 13 16:26:35 2023 +0200\r\n\r\n    Don't reallocate the buffer when we know its size\r\n    changelog:\r\n        section: perf\r\n        title: Improved processing speed by 10%\r\n        only-title: true";
 
         let exp_header = "commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -123,7 +123,7 @@ Date:   Tue Jun 13 16:26:35 2023 +0200";
         let exp_changelog_message = "
         section: perf
         title: Improved processing speed by 10%
-        title-is-enough: true";
+        only-title: true";
 
         let res = Commit::new(raw_data).unwrap();
         assert_eq!(res.header, exp_header);

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -39,7 +39,7 @@ impl Commit {
                 raw_data
             ))?;
 
-        let changelog = commit_iter.next().map(str::trim).ok_or(format!(
+        let changelog_message = commit_iter.next().ok_or(format!(
             "Missing 'changelog:' key in commit:\n>>> {}",
             raw_data
         ))?;
@@ -61,7 +61,7 @@ impl Commit {
             commit_id: commit_id.to_owned(),
             header: header.to_owned(),
             message: commit_message.trim().to_owned(),
-            changelog_message: changelog.to_owned(),
+            changelog_message: changelog_message.to_owned(),
             raw_data: raw_data.to_owned(),
         };
 
@@ -98,7 +98,8 @@ Date:   Tue Jun 13 16:26:35 2023 +0200";
     This computes the size and allocates the buffer upfront.
     Avoiding allocations like this introduces 10% speedup.";
 
-        let exp_changelog_message = "section: perf
+        let exp_changelog_message = "
+        section: perf
         title: Improved processing speed by 10%
         title-is-enough: true";
 
@@ -119,7 +120,8 @@ Date:   Tue Jun 13 16:26:35 2023 +0200";
 
         let exp_message = "Don't reallocate the buffer when we know its size";
 
-        let exp_changelog_message = "section: perf
+        let exp_changelog_message = "
+        section: perf
         title: Improved processing speed by 10%
         title-is-enough: true";
 

--- a/src/git/stdin.rs
+++ b/src/git/stdin.rs
@@ -26,7 +26,7 @@ impl super::GitLogCommand for Stdin {
 
         if !buf.starts_with("commit ") {
             // prepend fake header to make it look like valid commit
-            // when reading not-yet-commited commit
+            // when reading not-yet-committed commit
             buf.insert_str(0, "commit FROM STDIN\n\n")
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,8 @@ pub fn run(config: config::Config) -> Result<(), Box<dyn std::error::Error>> {
         &template.settings.projects_settings.projects,
     ) {
         (None, projects) => {
-            if !projects.is_empty() {
+            if !projects.is_empty() && !config.read_from_stdin {
+                // 'project' arg can be empty when reading from stdin (used in Github hook)
                 return Err(
                     "You need to specify project name. Use command 'help' for more information."
                         .into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ pub fn run(config: config::Config) -> Result<(), Box<dyn std::error::Error>> {
         &template.settings.projects_settings.projects,
     ) {
         (None, projects) => {
-            if !projects.is_empty() && !config.read_from_stdin {
-                // 'project' arg can be empty when reading from stdin (used in Github hook)
+            if !projects.is_empty() && config.command == Command::Generate {
+                // 'project' arg can be empty when we are just checking the commits, not generating a changelog
                 return Err(
                     "You need to specify project name. Use command 'help' for more information."
                         .into(),
@@ -81,12 +81,8 @@ pub fn run(config: config::Config) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let mut changelog = Changelog::new(&mut template, git);
-
-    let output = changelog.generate(config.project)?;
-
-    if let Command::Generate = config.command {
-        println!("{}", output);
-    }
+    let output = changelog.generate(config.project, config.command)?;
+    println!("{}", output);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,12 @@ pub fn run(config: config::Config) -> Result<(), Box<dyn std::error::Error>> {
         (None, None) => std::path::PathBuf::from("./"),
     };
 
+    if config.command == Command::CommitTemplate {
+        let output = template.generate_commit_template(std::io::stdin().lock())?;
+        println!("{}", output);
+        return Ok(());
+    }
+
     match (
         &config.project,
         &template.settings.projects_settings.projects,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,12 @@ use std::process;
 
 fn main() {
     let config = Config::new().unwrap_or_else(|err| {
-        eprintln!("{}", err);
+        eprintln!("Error: {}", err);
         process::exit(1);
     });
 
     if let Err(err) = mkchlog::run(config) {
-        eprintln!("{}", err);
+        eprintln!("Error: {}", err);
         process::exit(1);
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -239,7 +239,7 @@ impl<T: Default> Template<T> {
                     let indentation =
                         longest_section_name_len - keyword_len - sub_keyword_len - 1 + spaces;
 
-                    out.push(':');
+                    out.push('.');
                     out.push_str(keyword);
                     for _i in 0..indentation {
                         out.push(' ');
@@ -701,7 +701,7 @@ changelog:
 #
 # Valid changelog sections:
 #
-# * security:vuln_fixes  Fixed vulnerabilities
+# * security.vuln_fixes  Fixed vulnerabilities
 # * features             New features
 # * bug_fixes            Fixed bugs
 # * breaking             Breaking changes
@@ -739,7 +739,7 @@ changelog:
 #
 # Valid changelog sections:
 #
-# * security:vuln_fixes  Fixed vulnerabilities
+# * security.vuln_fixes  Fixed vulnerabilities
 # * features             New features
 # * bug_fixes            Fixed bugs
 # * breaking             Breaking changes
@@ -817,7 +817,7 @@ changelog:
 #
 # Valid changelog sections:
 #
-# * security:vuln_fixes  Fixed vulnerabilities
+# * security.vuln_fixes  Fixed vulnerabilities
 # * features             New features
 # * bug_fixes            Fixed bugs
 # * breaking             Breaking changes

--- a/src/template.rs
+++ b/src/template.rs
@@ -197,13 +197,26 @@ impl<T: Default> Template<T> {
         out.push_str("\n\n");
         out.push_str("changelog:\n");
         if !projects.is_empty() {
-            // TODO: API not yet stabilized
-            out.push_str("  project: ");
-            out.push_str(&projects.join(" | "));
-            out.push('\n');
+            if projects.len() == 1 {
+                out.push_str("  project: ");
+                out.push_str(projects[0]);
+                out.push('\n');
+                out.push_str("  section:\n");
+                out.push_str("  inherit: all\n");
+            } else {
+                for project in projects {
+                    out.push_str(" - project:\n");
+                    out.push_str("    name: ");
+                    out.push_str(project);
+                    out.push('\n');
+                    out.push_str("    section:\n");
+                    out.push_str("    inherit: all\n");
+                }
+            }
+        } else {
+            out.push_str("  section:\n");
+            out.push_str("  inherit: all\n");
         }
-        out.push_str("  section:\n");
-        out.push_str("  inherit: all\n");
 
         out.push_str("#\n");
         out.push_str("# Valid changelog sections:\n#");
@@ -729,13 +742,17 @@ commit.txt",
 
         let output = template.generate_commit_template(stdio).unwrap();
 
-        // TODO: correct the test when output is stabilized
         let exp_output = r"
 
 changelog:
-  project: main | mkchlog-action
-  section:
-  inherit: all
+ - project:
+    name: main
+    section:
+    inherit: all
+ - project:
+    name: mkchlog-action
+    section:
+    inherit: all
 #
 # Valid changelog sections:
 #

--- a/src/template.rs
+++ b/src/template.rs
@@ -202,7 +202,6 @@ impl<T: Default> Template<T> {
                 out.push_str(projects[0]);
                 out.push('\n');
                 out.push_str("  section:\n");
-                out.push_str("  inherit: all\n");
             } else {
                 for project in projects {
                     out.push_str(" - project:\n");
@@ -210,12 +209,10 @@ impl<T: Default> Template<T> {
                     out.push_str(project);
                     out.push('\n');
                     out.push_str("    section:\n");
-                    out.push_str("    inherit: all\n");
                 }
             }
         } else {
             out.push_str("  section:\n");
-            out.push_str("  inherit: all\n");
         }
 
         out.push_str("#\n");
@@ -710,7 +707,6 @@ commit.txt",
 changelog:
   project: main
   section:
-  inherit: all
 #
 # Valid changelog sections:
 #
@@ -748,11 +744,9 @@ changelog:
  - project:
     name: main
     section:
-    inherit: all
  - project:
     name: mkchlog-action
     section:
-    inherit: all
 #
 # Valid changelog sections:
 #
@@ -830,7 +824,6 @@ src/config.rs",
 
 changelog:
   section:
-  inherit: all
 #
 # Valid changelog sections:
 #

--- a/src/template.rs
+++ b/src/template.rs
@@ -147,7 +147,7 @@ impl<T: Default> Template<T> {
         mut changed_files: impl Read,
     ) -> Result<String, Box<dyn Error>> {
         let mut out = String::new();
-        let mut project = "";
+        let mut projects: Vec<&str> = vec![];
         if !self.settings.projects_settings.projects.is_empty() {
             let mut buf = String::new();
             changed_files.read_to_string(&mut buf)?;
@@ -156,43 +156,47 @@ impl<T: Default> Template<T> {
 
             for line in buf.lines() {
                 let file_path = PathBuf::from(line);
-                for (proj, dirs) in allowed_projects {
-                    for dir in dirs {
+                let mut file_found = false;
+                for (allowed_project, allowed_dirs) in allowed_projects {
+                    for dir in allowed_dirs {
+                        if file_found {
+                            break;
+                        }
+
                         if dir == &PathBuf::from(".") && file_path.parent() == Some(Path::new("")) {
                             // file is in main directory
-                            if !project.is_empty() && project != proj {
-                                return Err(
-                                    format!( "Cannot commit files that belong to different projects ({}, {})", project, proj).into(),
-                                 );
+                            if !projects.contains(&allowed_project.as_str()) {
+                                projects.push(allowed_project);
                             }
-                            project = proj;
+                            file_found = true;
                             break;
                         }
                         if file_path.starts_with(dir) {
                             // file is in subdirectory
-                            if !project.is_empty() && project != proj {
-                                return Err(
-                                   format!( "Cannot commit files that belong to different projects ({}, {})", project, proj).into(),
-                                );
+                            if !projects.contains(&allowed_project.as_str()) {
+                                projects.push(allowed_project);
                             }
-                            project = proj;
+                            file_found = true;
                             break;
                         }
                     }
                 }
-            }
-            if project.is_empty() {
-                // projects are configured, but we failed to determine one
-                // so we want to print 'project:' keyword to be filled out by the user
-                project = " ";
+                if !file_found {
+                    return Err(format!(
+                        "Could not determine project for file: '{}'. Is the directory correctly set in the config file?",
+                        file_path.display()
+                    )
+                    .into());
+                }
             }
         }
 
         out.push_str("\n\n");
         out.push_str("changelog:\n");
-        if !project.is_empty() {
+        if !projects.is_empty() {
+            // TODO: API not yet stabilized
             out.push_str("    project: ");
-            out.push_str(project);
+            out.push_str(&projects.join(" | "));
             out.push('\n');
         }
         out.push_str("    section:\n");
@@ -720,7 +724,6 @@ sections:
             "\
 .githooks/commit-msg
 README.md
-src/config.rs
 commit.txt",
         );
 
@@ -747,7 +750,7 @@ changelog:
     }
 
     #[test]
-    fn generate_commit_template_with_mixed_projects() {
+    fn generate_commit_template_with_changed_files_from_different_projects() {
         let f = FileReaderMock::new(
             r#"
 skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
@@ -790,16 +793,85 @@ sections:
 .githooks/commit-msg
 README.md
 mkchlog-action/README.md
-/src/config.rs
+commit.txt",
+        );
+
+        let output = template.generate_commit_template(stdio).unwrap();
+
+        // TODO: correct the test when output is stabilized
+        let exp_output = r"
+
+changelog:
+    project: main | mkchlog-action
+    section:
+    inherit: all
+#
+# Valid changelog sections:
+#
+# * security:vuln_fixes  Fixed vulnerabilities
+# * features             New features
+# * bug_fixes            Fixed bugs
+# * breaking             Breaking changes
+# * perf                 Performance improvements
+# * dev                  Development";
+
+        assert_eq!(exp_output, output);
+    }
+
+    #[test]
+    fn generate_commit_template_fails_when_could_not_determine_project() {
+        let f = FileReaderMock::new(
+            r#"
+skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
+
+projects:
+    list:
+    - main: [".", .github, .githooks]
+    - mkchlog: [mkchlog]
+    - mkchlog-action: [mkchlog-action]
+
+    since-commit: 276aa9e4b013de1646ea57cfcbf74e5966524f68 # projects are mandatory since COMMIT_NUMBER
+    default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME
+
+sections:
+    security:
+        title: Security
+        description: This section contains very important security-related changes.
+        subsections:
+            vuln_fixes:
+                title: Fixed vulnerabilities
+    features:
+        title: New features
+    bug_fixes:
+        title: Fixed bugs
+    breaking:
+        title: Breaking changes
+    perf:
+        title: Performance improvements
+    dev:
+        title: Development
+        description: Internal development changes
+"#,
+        );
+
+        let res = Template::<Changes>::new(f);
+        assert!(res.is_ok());
+        let template = res.unwrap();
+        let stdio = FileReaderMock::new(
+            "\
+.githooks/commit-msg
+README.md
+some_new_dir/README.md
 commit.txt",
         );
 
         let res = template.generate_commit_template(stdio);
+
         assert!(res.is_err());
         assert!(res
-            .unwrap_err()
-            .to_string()
-            .starts_with("Cannot commit files that belong to different projects"));
+        .unwrap_err()
+        .to_string()
+        .starts_with("Could not determine project for file: 'some_new_dir/README.md'. Is the directory correctly set in the config file?"));
     }
 
     #[test]

--- a/src/template.rs
+++ b/src/template.rs
@@ -195,12 +195,12 @@ impl<T: Default> Template<T> {
         out.push_str("changelog:\n");
         if !projects.is_empty() {
             // TODO: API not yet stabilized
-            out.push_str("    project: ");
+            out.push_str("  project: ");
             out.push_str(&projects.join(" | "));
             out.push('\n');
         }
-        out.push_str("    section:\n");
-        out.push_str("    inherit: all\n");
+        out.push_str("  section:\n");
+        out.push_str("  inherit: all\n");
 
         out.push_str("#\n");
         out.push_str("# Valid changelog sections:\n#");
@@ -732,9 +732,9 @@ commit.txt",
         let exp_output = r"
 
 changelog:
-    project: main
-    section:
-    inherit: all
+  project: main
+  section:
+  inherit: all
 #
 # Valid changelog sections:
 #
@@ -802,9 +802,9 @@ commit.txt",
         let exp_output = r"
 
 changelog:
-    project: main | mkchlog-action
-    section:
-    inherit: all
+  project: main | mkchlog-action
+  section:
+  inherit: all
 #
 # Valid changelog sections:
 #
@@ -913,8 +913,8 @@ src/config.rs",
         let exp_output = r"
 
 changelog:
-    section:
-    inherit: all
+  section:
+  inherit: all
 #
 # Valid changelog sections:
 #

--- a/src/template.rs
+++ b/src/template.rs
@@ -188,6 +188,7 @@ impl<T: Default> Template<T> {
             }
         }
 
+        out.push_str("#\n");
         out.push_str("#changelog:\n");
         if !project.is_empty() {
             out.push_str("#    project: ");
@@ -701,6 +702,7 @@ commit.txt",
         let output = template.generate_commit_template(stdio).unwrap();
 
         let exp_output = "\
+#
 #changelog:
 #    project: main
 #    section:
@@ -812,6 +814,7 @@ src/config.rs",
         let output = template.generate_commit_template(stdio).unwrap();
 
         let exp_output = "\
+#
 #changelog:
 #    section:
 #    inherit: all

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -36,7 +36,7 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
 
     changelog:
         section: dev
-        title-is-enough: true
+        only-title: true
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -67,7 +67,7 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
 
     changelog:
         section: features
-        title-is-enough: true
+        only-title: true
 
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -86,7 +86,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
 
     changelog:
             section: dev
-            title-is-enough: true
+            only-title: true
 
 commit 1cc72956df91e2fd8c45e72983c4e1149f1ac3b3
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -120,7 +120,7 @@ Date:   Tue Jun 13 16:26:35 2023 +0200
     changelog:
         section: perf
         title: Improved processing speed by 10%
-        title-is-enough: true
+        only-title: true
 
 commit a1a654e256cc96e1c4b5a81845b5e3f3f0aa9ed3
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -273,7 +273,7 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
 
     changelog:
             section: features
-            title-is-enough: true
+            only-title: true
 
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -354,13 +354,13 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        title-is-enough: true",
+        only-title: true",
     );
 
     let res = generate_changelog(mocked_log);
     assert!(res.is_err());
     assert!(res.unwrap_err().to_string().starts_with(
-        "changelog: missing field `section` at line 2 column 24 in changelog message in commit:"
+        "changelog: missing field `section` at line 2 column 19 in changelog message in commit:"
     ));
 }
 
@@ -402,7 +402,7 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
 
     changelog:
         section: dev
-        title-is-enough: true
+        only-title: true
 
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,5 @@
+//! Integration tests without multi-project settings
+
 mod mocks;
 
 use mkchlog::changelog;
@@ -8,6 +10,7 @@ use mocks::GitCmdMock;
 use std::fs::File;
 
 const YAML_FILE: &str = "tests/mkchlog.yml";
+const PROJECT: Option<String> = None;
 
 #[test]
 fn it_produces_correct_output() {
@@ -141,7 +144,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate().unwrap();
+    let output = changelog.generate(PROJECT).unwrap();
 
     let exp_output = "\
 ============================================
@@ -222,7 +225,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate().unwrap();
+    let output = changelog.generate(PROJECT).unwrap();
 
     let exp_output = "\
 ============================================
@@ -302,7 +305,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate().unwrap();
+    let output = changelog.generate(PROJECT).unwrap();
 
     let exp_output = "\
 ============================================
@@ -351,7 +354,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let res = changelog.generate();
+    let res = changelog.generate(PROJECT);
 
     assert!(res.is_err());
     assert!(res
@@ -385,7 +388,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let res = changelog.generate();
+    let res = changelog.generate(PROJECT);
 
     assert!(res.is_err());
     assert!(res
@@ -427,7 +430,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate().unwrap();
+    let output = changelog.generate(PROJECT).unwrap();
 
     let exp_output = "\
 ============================================
@@ -484,7 +487,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate().unwrap();
+    let output = changelog.generate(PROJECT).unwrap();
 
     let exp_output = "\
 ============================================

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -28,6 +28,18 @@ fn generate_changelog(mocked_log: String) -> Result<String, Box<dyn std::error::
 fn it_produces_correct_output() {
     let mocked_log = String::from(
         "\
+commit 68b0e70191bf2525f7ee96f54e2dbccc940dcbfd (HEAD -> projects2)
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Dec 5 20:25:07 2023 +0100
+
+    Add optional list of commit IDs to skip
+
+    You can provide list of commit numbers to skip in the config template. Useful in case you want to simply revoke some obsolete or wrong commit message.
+
+    changelog:
+        section: features
+        title: List of commit IDs to skip
+
 commit 12b6a464d165c18cc29394e332d6f6c6d09170e2
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Fri Oct 27 20:22:58 2023 +0200
@@ -184,6 +196,10 @@ If your working directory is **not** accessible by unprivileged users you don't 
 ## New features
 
 * Support building on Debian Bookworm
+
+### List of commit IDs to skip
+
+You can provide list of commit numbers to skip in the config template. Useful in case you want to simply revoke some obsolete or wrong commit message.
 
 ### Allow configuring commit ID in yaml
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -39,8 +39,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         inherit: title
         title-is-enough: true
 
-.github/workflows/ci.yml
-
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Sun Oct 22 23:08:57 2023 +0200
@@ -54,12 +52,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
     changelog:
         section: features
         inherit: all
-
-.mkchlog.yml
-README.md
-src/lib.rs
-src/template.rs
-tests/mkchlog.yml
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -79,13 +71,6 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
-.github/workflows/test.yml
-Cargo.lock
-Cargo.toml
-README.md
-clippy.toml
-src/template.rs
-
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -104,12 +89,6 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             section: dev
             title-is-enough: true
-
-.github/workflows/changelog.yml
-.github/workflows/test.yml
-.mkchlog.yml
-tests/integration_test.rs
-tests/mkchlog.yml
 
 commit 1cc72956df91e2fd8c45e72983c4e1149f1ac3b3
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -131,11 +110,6 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                      working directory is **not** accessible by
                      unprivileged users you don't need to worry.
 
-src/bip324.cpp
-src/bip324.h
-src/crypto/chacha20poly1305.cpp
-src/crypto/chacha20poly1305.h
-
 commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:26:35 2023 +0200
@@ -150,8 +124,6 @@ Date:   Tue Jun 13 16:26:35 2023 +0200
         title: Improved processing speed by 10%
         title-is-enough: true
 
-src/key_io.cpp
-
 commit a1a654e256cc96e1c4b5a81845b5e3f3f0aa9ed3
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:25:29 2023 +0200
@@ -161,8 +133,6 @@ Date:   Tue Jun 13 16:25:29 2023 +0200
     We found 42 grammar mistakes that are fixed in this commit.
 
     changelog: skip
-
-README.md
 
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -176,9 +146,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features
-
-src/changelog.rs",
+        section: features",
     );
 
     let output = generate_changelog(mocked_log).unwrap();
@@ -250,12 +218,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                      directory. If you run this in such
                      enviroment you should update ASAP. If your
                      working directory is **not** accessible by
-                     unprivileged users you don't need to worry.
-
-src/bip324.cpp
-src/bip324.h
-src/crypto/chacha20poly1305.cpp
-src/crypto/chacha20poly1305.h",
+                     unprivileged users you don't need to worry.",
     );
 
     let output = generate_changelog(mocked_log).unwrap();
@@ -298,12 +261,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         section: features
         inherit: all
 
-.mkchlog.yml
-README.md
-src/lib.rs
-src/template.rs
-tests/mkchlog.yml
-
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 09:12:50 2023 +0200
@@ -322,13 +279,6 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
             section: features
             title-is-enough: true
 
-.github/workflows/test.yml
-Cargo.lock
-Cargo.toml
-README.md
-clippy.toml
-src/template.rs
-
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -341,9 +291,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features
-
-src/changelog.rs",
+        section: features",
     );
 
     let output = generate_changelog(mocked_log).unwrap();
@@ -385,9 +333,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: unconfigured_section
-
-src/changelog.rs",
+        section: unconfigured_section",
     );
 
     let res = generate_changelog(mocked_log);
@@ -414,9 +360,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        inherit: all
-
-src/changelog.rs",
+        inherit: all",
     );
 
     let res = generate_changelog(mocked_log);
@@ -443,8 +387,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         inherit: title
         title-is-enough: true
 
-.github/workflows/ci.yml
-
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -453,9 +395,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features
-
-src/changelog.rs",
+        section: features",
     );
 
     let output = generate_changelog(mocked_log).unwrap();
@@ -479,7 +419,7 @@ Internal development changes
 }
 
 #[test]
-fn inherit_title_and_description() {
+fn inherit_title_and_provide_description() {
     let mocked_log = String::from(
         "\
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
@@ -497,12 +437,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         The new `.mkchlog.yml` is heavily inspired by the original example with
         more sections, so we're more flexible in the future.
 
-.github/workflows/changelog.yml
-.github/workflows/test.yml
-.mkchlog.yml
-tests/integration_test.rs
-tests/mkchlog.yml
-
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -511,9 +445,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: dev
-
-.github/workflows/ci.yml",
+        section: dev",
     );
 
     let output = generate_changelog(mocked_log).unwrap();
@@ -558,12 +490,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                      directory. If you run this in such
                      enviroment you should update ASAP. If your
                      working directory is **not** accessible by
-                     unprivileged users you don't need to worry.
-
-src/bip324.cpp
-src/bip324.h
-src/crypto/chacha20poly1305.cpp
-src/crypto/chacha20poly1305.h",
+                     unprivileged users you don't need to worry.",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -596,9 +523,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: unconfigured_section
-
-src/changelog.rs",
+        section: unconfigured_section",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -36,7 +36,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
 
     changelog:
         section: dev
-        inherit: title
         title-is-enough: true
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
@@ -51,7 +50,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
 
     changelog:
         section: features
-        inherit: all
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -145,7 +143,6 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        inherit: all
         section: features",
     );
 
@@ -259,7 +256,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
 
     changelog:
         section: features
-        inherit: all
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -290,7 +286,6 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        inherit: all
         section: features",
     );
 
@@ -332,7 +327,6 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        inherit: all
         section: unconfigured_section",
     );
 
@@ -360,13 +354,13 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        inherit: all",
+        title-is-enough: true",
     );
 
     let res = generate_changelog(mocked_log);
     assert!(res.is_err());
     assert!(res.unwrap_err().to_string().starts_with(
-        "changelog: missing field `section` at line 2 column 16 in changelog message in commit:"
+        "changelog: missing field `section` at line 2 column 24 in changelog message in commit:"
     ));
 }
 
@@ -385,8 +379,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        section:
-        inherit: all",
+        section:",
     );
 
     let res = generate_changelog(mocked_log);
@@ -409,7 +402,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
 
     changelog:
         section: dev
-        inherit: title
         title-is-enough: true
 
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
@@ -419,7 +411,6 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     Added ability to skip commits.
 
     changelog:
-        inherit: all
         section: features",
     );
 
@@ -455,7 +446,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
 
     changelog:
         section: dev
-        inherit: title
         description: This configures github actions to test `mkchlog` as well as run it on
             its own repository.
 
@@ -469,7 +459,6 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     Setup CI
 
     changelog:
-        inherit: all
         section: dev",
     );
 
@@ -548,7 +537,6 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        inherit: all
         section: unconfigured_section",
     );
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,13 +4,15 @@ mod mocks;
 
 use mkchlog::changelog;
 use mkchlog::changelog::Changelog;
+use mkchlog::config::Command;
 use mkchlog::git::Git;
 use mkchlog::template::Template;
 use mocks::GitCmdMock;
 use std::fs::File;
 
 const YAML_FILE: &str = "tests/mkchlog.yml";
-const PROJECT: Option<String> = None;
+const PROJECT_NONE: Option<String> = None;
+const COMMAND: Command = Command::Generate;
 
 #[test]
 fn it_produces_correct_output() {
@@ -27,6 +29,8 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         inherit: title
         title-is-enough: true
 
+.github/workflows/ci.yml
+
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Sun Oct 22 23:08:57 2023 +0200
@@ -40,6 +44,12 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
     changelog:
         section: features
         inherit: all
+
+.mkchlog.yml
+README.md
+src/lib.rs
+src/template.rs
+tests/mkchlog.yml
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -59,6 +69,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
+.github/workflows/test.yml
+Cargo.lock
+Cargo.toml
+README.md
+clippy.toml
+src/template.rs
+
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -77,6 +94,12 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             section: dev
             title-is-enough: true
+
+.github/workflows/changelog.yml
+.github/workflows/test.yml
+.mkchlog.yml
+tests/integration_test.rs
+tests/mkchlog.yml
 
 commit 1cc72956df91e2fd8c45e72983c4e1149f1ac3b3
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -98,6 +121,11 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                      working directory is **not** accessible by
                      unprivileged users you don't need to worry.
 
+src/bip324.cpp
+src/bip324.h
+src/crypto/chacha20poly1305.cpp
+src/crypto/chacha20poly1305.h
+
 commit 7c85bee4303d56bededdfacf8fbb7bdc68e2195b
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:26:35 2023 +0200
@@ -112,6 +140,8 @@ Date:   Tue Jun 13 16:26:35 2023 +0200
         title: Improved processing speed by 10%
         title-is-enough: true
 
+src/key_io.cpp
+
 commit a1a654e256cc96e1c4b5a81845b5e3f3f0aa9ed3
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:25:29 2023 +0200
@@ -121,6 +151,8 @@ Date:   Tue Jun 13 16:25:29 2023 +0200
     We found 42 grammar mistakes that are fixed in this commit.
 
     changelog: skip
+
+README.md
 
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -134,7 +166,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features",
+        section: features
+
+src/changelog.rs",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -144,7 +178,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate(PROJECT).unwrap();
+    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -215,7 +249,10 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
                      working directory is **not** accessible by
                      unprivileged users you don't need to worry.
 
-",
+src/bip324.cpp
+src/bip324.h
+src/crypto/chacha20poly1305.cpp
+src/crypto/chacha20poly1305.h",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -225,7 +262,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate(PROJECT).unwrap();
+    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -265,6 +302,12 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         section: features
         inherit: all
 
+.mkchlog.yml
+README.md
+src/lib.rs
+src/template.rs
+tests/mkchlog.yml
+
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 09:12:50 2023 +0200
@@ -283,6 +326,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
             section: features
             title-is-enough: true
 
+.github/workflows/test.yml
+Cargo.lock
+Cargo.toml
+README.md
+clippy.toml
+src/template.rs
+
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -295,7 +345,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features",
+        section: features
+
+src/changelog.rs",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -305,7 +357,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate(PROJECT).unwrap();
+    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -344,7 +396,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: unconfigured_section",
+        section: unconfigured_section
+
+src/changelog.rs",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -354,7 +408,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let res = changelog.generate(PROJECT);
+    let res = changelog.generate(PROJECT_NONE, COMMAND);
 
     assert!(res.is_err());
     assert!(res
@@ -378,7 +432,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        inherit: all",
+        inherit: all
+
+src/changelog.rs",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -388,7 +444,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let res = changelog.generate(PROJECT);
+    let res = changelog.generate(PROJECT_NONE, COMMAND);
 
     assert!(res.is_err());
     assert!(res
@@ -412,6 +468,8 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         inherit: title
         title-is-enough: true
 
+.github/workflows/ci.yml
+
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -420,7 +478,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: features",
+        section: features
+
+src/changelog.rs",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -430,7 +490,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate(PROJECT).unwrap();
+    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -469,6 +529,12 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         The new `.mkchlog.yml` is heavily inspired by the original example with
         more sections, so we're more flexible in the future.
 
+.github/workflows/changelog.yml
+.github/workflows/test.yml
+.mkchlog.yml
+tests/integration_test.rs
+tests/mkchlog.yml
+
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Jun 13 16:24:22 2023 +0200
@@ -477,7 +543,9 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: dev",
+        section: dev
+
+.github/workflows/ci.yml",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -487,7 +555,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
-    let output = changelog.generate(PROJECT).unwrap();
+    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -505,4 +573,85 @@ This configures github actions to test `mkchlog` as well as run it on its own re
 ============================================";
 
     assert_eq!(exp_output, output);
+}
+
+#[test]
+fn when_called_with_check_command_does_not_print_anything() {
+    let mocked_log = String::from(
+        "\
+commit 1cc72956df91e2fd8c45e72983c4e1149f1ac3b3
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Jun 13 16:27:59 2023 +0200
+
+    Fixed TOCTOU race condition when opening file
+
+    Previously we checked the file permissions before opening
+    the file now we check the metadata using file descriptor
+    after opening the file. (before reading)
+
+    changelog:
+        section: security:vuln_fixes
+        title: Fixed vulnerability related to opening files
+        description: The application was vulnerable to attacks
+                     if the attacker had access to the working
+                     directory. If you run this in such
+                     enviroment you should update ASAP. If your
+                     working directory is **not** accessible by
+                     unprivileged users you don't need to worry.
+
+src/bip324.cpp
+src/bip324.h
+src/crypto/chacha20poly1305.cpp
+src/crypto/chacha20poly1305.h",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let output = changelog.generate(PROJECT_NONE, Command::Check).unwrap();
+
+    let exp_output = "";
+
+    assert_eq!(exp_output, output);
+}
+
+#[test]
+fn when_called_with_check_command_fails_if_commits_invalid() {
+    let mocked_log = String::from(
+        "\
+commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Jun 13 16:24:22 2023 +0200
+
+    Added ability to skip commits.
+
+    This allows commits to be skipped by typing 'changelog: skip'
+    at the end of the commit. This is mainly useful for typo
+    fixes or other things irrelevant to the user of a project.
+
+    changelog:
+        inherit: all
+        section: unconfigured_section
+
+src/changelog.rs",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let res = changelog.generate(PROJECT_NONE, Command::Check);
+
+    assert!(res.is_err());
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .starts_with("Unknown section 'unconfigured_section' in changelog message"));
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -28,6 +28,15 @@ fn generate_changelog(mocked_log: String) -> Result<String, Box<dyn std::error::
 fn it_produces_correct_output() {
     let mocked_log = String::from(
         "\
+commit 12b6a464d165c18cc29394e332d6f6c6d09170e2
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Fri Oct 27 20:22:58 2023 +0200
+
+    Fix forgotten import in Wasm
+
+    changelog:
+        section: features
+
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -87,6 +96,15 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             section: dev
             only-title: true
+
+commit a27c77b683c6334e79e94c232ed699f5a5216fee
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Fri Sep 8 18:20:52 2023 +0100
+
+    'project' arg can be empty when reading from stdin even in multi-prject repo (used in Github hook)
+
+    changelog:
+        section: features
 
 commit 1cc72956df91e2fd8c45e72983c4e1149f1ac3b3
 Author: Cry Wolf <cry.wolf@centrum.cz>

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -101,7 +101,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
     after opening the file. (before reading)
 
     changelog:
-        section: security:vuln_fixes
+        section: security.vuln_fixes
         title: Fixed vulnerability related to opening files
         description: The application was vulnerable to attacks
                      if the attacker had access to the working
@@ -211,7 +211,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
     after opening the file. (before reading)
 
     changelog:
-        section: security:vuln_fixes
+        section: security.vuln_fixes
         title: Fixed vulnerability related to opening files
         description: The application was vulnerable to attacks
                      if the attacker had access to the working
@@ -483,7 +483,7 @@ Date:   Tue Jun 13 16:27:59 2023 +0200
     after opening the file. (before reading)
 
     changelog:
-        section: security:vuln_fixes
+        section: security.vuln_fixes
         title: Fixed vulnerability related to opening files
         description: The application was vulnerable to attacks
                      if the attacker had access to the working

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8,11 +8,21 @@ use mkchlog::config::Command;
 use mkchlog::git::Git;
 use mkchlog::template::Template;
 use mocks::GitCmdMock;
-use std::fs::File;
 
 const YAML_FILE: &str = "tests/mkchlog.yml";
 const PROJECT_NONE: Option<String> = None;
 const COMMAND: Command = Command::Generate;
+
+fn generate_changelog(mocked_log: String) -> Result<String, Box<dyn std::error::Error>> {
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = std::fs::File::open(YAML_FILE).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    changelog.generate(PROJECT_NONE, COMMAND)
+}
 
 #[test]
 fn it_produces_correct_output() {
@@ -171,14 +181,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 src/changelog.rs",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
-    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
+    let output = generate_changelog(mocked_log).unwrap();
 
     let exp_output = "\
 ============================================
@@ -255,14 +258,7 @@ src/crypto/chacha20poly1305.cpp
 src/crypto/chacha20poly1305.h",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
-    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
+    let output = generate_changelog(mocked_log).unwrap();
 
     let exp_output = "\
 ============================================
@@ -350,14 +346,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 src/changelog.rs",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
-    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
+    let output = generate_changelog(mocked_log).unwrap();
 
     let exp_output = "\
 ============================================
@@ -401,14 +390,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 src/changelog.rs",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
-    let res = changelog.generate(PROJECT_NONE, COMMAND);
+    let res = generate_changelog(mocked_log);
 
     assert!(res.is_err());
     assert!(res
@@ -437,14 +419,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 src/changelog.rs",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
-    let res = changelog.generate(PROJECT_NONE, COMMAND);
+    let res = generate_changelog(mocked_log);
 
     assert!(res.is_err());
     assert!(res
@@ -483,14 +458,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 src/changelog.rs",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
-    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
+    let output = generate_changelog(mocked_log).unwrap();
 
     let exp_output = "\
 ============================================
@@ -548,14 +516,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 .github/workflows/ci.yml",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
-    let output = changelog.generate(PROJECT_NONE, COMMAND).unwrap();
+    let output = generate_changelog(mocked_log).unwrap();
 
     let exp_output = "\
 ============================================
@@ -608,7 +569,7 @@ src/crypto/chacha20poly1305.h",
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
     let git = Git::new(git_cmd);
 
-    let f = File::open(YAML_FILE).unwrap();
+    let f = std::fs::File::open(YAML_FILE).unwrap();
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 
@@ -643,7 +604,7 @@ src/changelog.rs",
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
     let git = Git::new(git_cmd);
 
-    let f = File::open(YAML_FILE).unwrap();
+    let f = std::fs::File::open(YAML_FILE).unwrap();
     let mut template = Template::<changelog::Changes>::new(f).unwrap();
     let mut changelog = Changelog::new(&mut template, git);
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -364,12 +364,37 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     );
 
     let res = generate_changelog(mocked_log);
+    assert!(res.is_err());
+    assert!(res.unwrap_err().to_string().starts_with(
+        "changelog: missing field `section` at line 2 column 16 in changelog message in commit:"
+    ));
+}
 
+#[test]
+fn fails_when_empty_section_key_in_commit() {
+    let mocked_log = String::from(
+        "\
+commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Jun 13 16:24:22 2023 +0200
+
+    Added ability to skip commits.
+
+    This allows commits to be skipped by typing 'changelog: skip'
+    at the end of the commit. This is mainly useful for typo
+    fixes or other things irrelevant to the user of a project.
+
+    changelog:
+        section:
+        inherit: all",
+    );
+
+    let res = generate_changelog(mocked_log);
     assert!(res.is_err());
     assert!(res
         .unwrap_err()
         .to_string()
-        .starts_with("Missing 'section' key in changelog message:"));
+        .starts_with("Unknown section '~' in changelog message in commit:"));
 }
 
 #[test]
@@ -432,10 +457,10 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         description: This configures github actions to test `mkchlog` as well as run it on
-        its own repository.
+            its own repository.
 
-        The new `.mkchlog.yml` is heavily inspired by the original example with
-        more sections, so we're more flexible in the future.
+            The new `.mkchlog.yml` is heavily inspired by the original example with
+            more sections, so we're more flexible in the future.
 
 commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -461,7 +486,8 @@ Internal development changes
 
 ### Setup Github Actions
 
-This configures github actions to test `mkchlog` as well as run it on its own repository.  The new `.mkchlog.yml` is heavily inspired by the original example with more sections, so we're more flexible in the future.
+This configures github actions to test `mkchlog` as well as run it on its own repository.
+The new `.mkchlog.yml` is heavily inspired by the original example with more sections, so we're more flexible in the future.
 
 ============================================";
 
@@ -534,7 +560,6 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     let mut changelog = Changelog::new(&mut template, git);
 
     let res = changelog.generate(PROJECT_NONE, Command::Check);
-
     assert!(res.is_err());
     assert!(res
         .unwrap_err()

--- a/tests/integration_test_projects.rs
+++ b/tests/integration_test_projects.rs
@@ -84,7 +84,7 @@ Date:   Tue Oct 31 13:46:59 2023 +0100
     It is possible to check the commit before it is actually committed. Useful to use in a commit-msg git hook.
 
     changelog:
-        project:main
+        project: main
         section: features
         inherit: all
 
@@ -282,6 +282,115 @@ This updates the wasm module to one which was compiled with `--release`.
 ## Documentation changes
 
 * Add configuration instructions to README.md
+
+============================================";
+
+    assert_eq!(exp_output, output);
+}
+
+#[test]
+fn commits_with_more_projects_should_work() {
+    let mocked_log = String::from(
+        "\
+commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Oct 24 19:17:09 2023 +0200
+
+    Setup CI
+
+    Setup CI + update dependency in mkchlog-action
+
+    changelog:
+     - project:
+        name: mkchlog
+        section: dev
+        inherit: all
+        title-is-enough: true
+     - project:
+        name: mkchlog-action
+        section: features
+        inherit: all
+",
+    );
+
+    let project = Some("mkchlog".to_owned());
+    let output = generate_changelog(mocked_log.clone(), YAML_FILE_PROJECTS, project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## Development
+
+Internal development changes
+
+* Setup CI
+
+============================================";
+
+    assert_eq!(exp_output, output);
+
+    let project = Some("mkchlog-action".to_owned());
+    let output = generate_changelog(mocked_log, YAML_FILE_PROJECTS, project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## New features
+
+### Setup CI
+
+Setup CI + update dependency in mkchlog-action
+
+============================================";
+
+    assert_eq!(exp_output, output);
+}
+
+#[test]
+fn commits_with_more_projects_should_work_one_project_skip() {
+    let mocked_log = String::from(
+        "\
+commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Oct 24 19:17:09 2023 +0200
+
+    Setup CI
+
+    Setup CI + update dependency in mkchlog-action
+
+    changelog:
+     - project:
+        name: mkchlog
+        section: dev
+        inherit: title
+        title-is-enough: true
+     - project:
+        name: mkchlog-action
+        skip: true
+",
+    );
+
+    let project = Some("mkchlog".to_owned());
+    let output = generate_changelog(mocked_log.clone(), YAML_FILE_PROJECTS, project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## Development
+
+Internal development changes
+
+* Setup CI
+
+============================================";
+
+    assert_eq!(exp_output, output);
+
+    let project = Some("mkchlog-action".to_owned());
+    let output = generate_changelog(mocked_log, YAML_FILE_PROJECTS, project).unwrap();
+
+    let exp_output = "\
+============================================
 
 ============================================";
 

--- a/tests/integration_test_projects.rs
+++ b/tests/integration_test_projects.rs
@@ -1,3 +1,5 @@
+//! Integration tests with multi-project settings
+
 mod mocks;
 
 use mkchlog::changelog;
@@ -46,8 +48,6 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
-mkchlog-action/README.md
-
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -59,8 +59,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
-
-mkchlog/.github/workflows/ci.yml
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -77,12 +75,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
-mkchlog/.mkchlog.yml
-mkchlog/README.md
-mkchlog/src/lib.rs
-mkchlog/src/template.rs
-mkchlog/tests/mkchlog.yml
-
 commit ac0df22c6b5c9e4ec387b61b7997d420a1b6d36c
 Author: Vojtěch Toman <cry.wolf@centrum.cz>
 Date:   Tue Oct 31 13:46:59 2023 +0100
@@ -96,9 +88,6 @@ Date:   Tue Oct 31 13:46:59 2023 +0100
         section: features
         inherit: all
 
-.githooks/commit-msg
-README.md
-
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -111,9 +100,6 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
-
-mkchlog-action/node_modules/libmkchlog/libmkchlog.js
-mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -134,13 +120,6 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
-mkchlog/.github/workflows/test.yml
-mkchlog/Cargo.lock
-mkchlog/Cargo.toml
-mkchlog/README.md
-mkchlog/clippy.toml
-mkchlog/src/template.rs
-
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -159,13 +138,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             project: mkchlog
             section: dev
-            title-is-enough: true
-
-mkchlog/.github/workflows/changelog.yml
-mkchlog/.github/workflows/test.yml
-mkchlog/.mkchlog.yml
-mkchlog/tests/integration_test.rs
-mkchlog/tests/mkchlog.yml",
+            title-is-enough: true",
     );
 
     let project = Some("mkchlog".to_owned());
@@ -214,8 +187,6 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
-mkchlog-action/README.md
-
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -227,8 +198,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
-
-mkchlog/.github/workflows/ci.yml
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -245,12 +214,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
-mkchlog/.mkchlog.yml
-mkchlog/README.md
-mkchlog/src/lib.rs
-mkchlog/src/template.rs
-mkchlog/tests/mkchlog.yml
-
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -263,9 +226,6 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
-
-mkchlog-action/node_modules/libmkchlog/libmkchlog.js
-mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -286,13 +246,6 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
-mkchlog/.github/workflows/test.yml
-mkchlog/Cargo.lock
-mkchlog/mkchlog/Cargo.toml
-mkchlog/README.md
-mkchlog/clippy.toml
-mkchlog/src/template.rs
-
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -311,13 +264,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             project: mkchlog
             section: dev
-            title-is-enough: true
-
-mkchlog/.github/workflows/changelog.yml
-mkchlog/.github/workflows/test.yml
-mkchlog/.mkchlog.yml
-mkchlog/tests/integration_test.rs
-mkchlog/tests/mkchlog.yml",
+            title-is-enough: true",
     );
 
     let project = Some("mkchlog-action".to_owned());
@@ -372,10 +319,7 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         project: wrong-name
         section: doc
         inherit: title
-        title-is-enough: true
-
-README.md
-    ",
+        title-is-enough: true",
     );
 
     let project = Some("mkchlog".to_owned());
@@ -385,38 +329,6 @@ README.md
     assert!(res.unwrap_err().to_string().starts_with(
         "Incorrect (not allowed in config file) project name 'wrong-name' in changelog message"
     ));
-}
-
-#[test]
-fn fails_when_commit_changes_files_that_are_not_in_project_directory() {
-    let mocked_log = String::from(
-        "\
-commit ac0df22c6b5c9e4ec387b61b7997d420a1b6d36c
-Author: Vojtěch Toman <cry.wolf@centrum.cz>
-Date:   Tue Oct 31 13:46:59 2023 +0100
-
-    Allow parsing commit(s) from stdin
-
-    It is possible to check the commit before it is actually commited. Useful to use in a commit-msg git hook.
-
-    changelog:
-        project: main
-        section: features
-        inherit: all
-
-.githooks/commit-msg
-README.md
-src/config.rs",
-    );
-
-    let project = Some("mkchlog".to_owned());
-    let res = generate_changelog(mocked_log, YAML_FILE_PROJECTS, project);
-
-    assert!(res.is_err());
-    assert!(res
-        .unwrap_err()
-        .to_string()
-        .starts_with("File: 'src/config.rs' does not belong to project 'main' in commit:"));
 }
 
 #[test]
@@ -438,8 +350,6 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
-mkchlog-action/README.md
-
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -451,8 +361,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
-
-mkchlog/.github/workflows/ci.yml
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -469,12 +377,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
-mkchlog/.mkchlog.yml
-mkchlog/README.md
-mkchlog/src/lib.rs
-mkchlog/src/template.rs
-mkchlog/tests/mkchlog.yml
-
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -487,9 +389,6 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
-
-mkchlog-action/node_modules/libmkchlog/libmkchlog.js
-mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -509,13 +408,6 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
-.github/workflows/test.yml
-Cargo.lock
-Cargo.toml
-README.md
-clippy.toml
-src/template.rs
-
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -533,13 +425,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
 
     changelog:
             section: dev
-            title-is-enough: true
-
-.github/workflows/changelog.yml
-.github/workflows/test.yml
-.mkchlog.yml
-tests/integration_test.rs
-tests/mkchlog.yml",
+            title-is-enough: true",
     );
 
     let project = Some("mkchlog".to_owned());
@@ -588,8 +474,6 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
-mkchlog-action/README.md
-
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -601,9 +485,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
-
-mkchlog/.github/workflows/ci.yml
-mkchlog/README.md
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -620,12 +501,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
-mkchlog/.mkchlog.yml
-mkchlog/README.md
-mkchlog/src/lib.rs
-mkchlog/src/template.rs
-mkchlog/tests/mkchlog.yml
-
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -638,9 +513,6 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
-
-mkchlog-action/node_modules/libmkchlog/libmkchlog.js
-mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -660,13 +532,6 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
-.github/workflows/test.yml
-Cargo.lock
-Cargo.toml
-README.md
-clippy.toml
-src/template.rs
-
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -684,13 +549,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
 
     changelog:
             section: dev
-            title-is-enough: true
-
-.github/workflows/changelog.yml
-.github/workflows/test.yml
-.mkchlog.yml
-tests/integration_test.rs
-tests/mkchlog.yml",
+            title-is-enough: true",
     );
 
     let project = Some("mkchlog-action".to_owned());
@@ -716,7 +575,7 @@ This updates the wasm module to one which was compiled with `--release`.
 
 #[test]
 fn when_called_with_check_command_fails_if_commits_are_invalid() {
-    // test that we can call it without providing project name when just checking commits, not generating changelog
+    // test that we can call the command without providing project name when just checking commits, not generating changelog
     // and it will correctly find commit with invalid or missing project
 
     let mocked_log = String::from(
@@ -733,9 +592,7 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
 
     changelog:
         inherit: all
-        section: feature
-
-src/changelog.rs",
+        section: feature",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));

--- a/tests/integration_test_projects.rs
+++ b/tests/integration_test_projects.rs
@@ -12,6 +12,21 @@ const YAML_FILE_PROJECTS: &str = "tests/mkchlog_projects.yml";
 const YAML_FILE_SINCE_COMMIT: &str = "tests/mkchlog_projects_since_commit.yml";
 const COMMAND: Command = Command::Generate;
 
+fn generate_changelog(
+    mocked_log: String,
+    yaml_file: &str,
+    project: Option<String>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(yaml_file).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    changelog.generate(project, COMMAND)
+}
+
 #[test]
 fn it_produces_correct_output_for_project1() {
     let mocked_log = String::from(
@@ -153,15 +168,8 @@ mkchlog/tests/integration_test.rs
 mkchlog/tests/mkchlog.yml",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE_PROJECTS).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
     let project = Some("mkchlog".to_owned());
-    let output = changelog.generate(project, COMMAND).unwrap();
+    let output = generate_changelog(mocked_log, YAML_FILE_PROJECTS, project).unwrap();
 
     let exp_output = "\
 ============================================
@@ -312,15 +320,8 @@ mkchlog/tests/integration_test.rs
 mkchlog/tests/mkchlog.yml",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE_PROJECTS).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
     let project = Some("mkchlog-action".to_owned());
-    let output = changelog.generate(project, COMMAND).unwrap();
+    let output = generate_changelog(mocked_log, YAML_FILE_PROJECTS, project).unwrap();
 
     let exp_output = "\
 ============================================
@@ -344,15 +345,8 @@ This updates the wasm module to one which was compiled with `--release`.
 fn fails_when_called_with_incorrect_project_argument_provided_when_calling_the_app() {
     let mocked_log = String::from("");
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE_PROJECTS).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
     let project = Some("nonsense".to_owned());
-    let res = changelog.generate(project, COMMAND);
+    let res = generate_changelog(mocked_log, YAML_FILE_PROJECTS, project);
 
     assert!(res.is_err());
     assert!(res
@@ -384,15 +378,8 @@ README.md
     ",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE_PROJECTS).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
     let project = Some("mkchlog".to_owned());
-    let res = changelog.generate(project, COMMAND);
+    let res = generate_changelog(mocked_log, YAML_FILE_PROJECTS, project);
 
     assert!(res.is_err());
     assert!(res.unwrap_err().to_string().starts_with(
@@ -422,15 +409,8 @@ README.md
 src/config.rs",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE_PROJECTS).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
     let project = Some("mkchlog".to_owned());
-    let res = changelog.generate(project, COMMAND);
+    let res = generate_changelog(mocked_log, YAML_FILE_PROJECTS, project);
 
     assert!(res.is_err());
     assert!(res
@@ -562,15 +542,8 @@ tests/integration_test.rs
 tests/mkchlog.yml",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE_SINCE_COMMIT).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
     let project = Some("mkchlog".to_owned());
-    let output = changelog.generate(project, COMMAND).unwrap();
+    let output = generate_changelog(mocked_log, YAML_FILE_SINCE_COMMIT, project).unwrap();
 
     let exp_output = "\
 ============================================
@@ -720,15 +693,8 @@ tests/integration_test.rs
 tests/mkchlog.yml",
     );
 
-    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
-    let git = Git::new(git_cmd);
-
-    let f = File::open(YAML_FILE_SINCE_COMMIT).unwrap();
-    let mut template = Template::<changelog::Changes>::new(f).unwrap();
-    let mut changelog = Changelog::new(&mut template, git);
-
     let project = Some("mkchlog-action".to_owned());
-    let output = changelog.generate(project, COMMAND).unwrap();
+    let output = generate_changelog(mocked_log, YAML_FILE_SINCE_COMMIT, project).unwrap();
 
     let exp_output = "\
 ============================================

--- a/tests/integration_test_projects.rs
+++ b/tests/integration_test_projects.rs
@@ -81,7 +81,7 @@ Date:   Tue Oct 31 13:46:59 2023 +0100
 
     Allow parsing commit(s) from stdin
 
-    It is possible to check the commit before it is actually commited. Useful to use in a commit-msg git hook.
+    It is possible to check the commit before it is actually committed. Useful to use in a commit-msg git hook.
 
     changelog:
         project:main

--- a/tests/integration_test_projects.rs
+++ b/tests/integration_test_projects.rs
@@ -45,7 +45,6 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: doc
-        inherit: title
         title-is-enough: true
 
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
@@ -57,7 +56,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
     changelog:
         project: mkchlog
         section: dev
-        inherit: title
         title-is-enough: true
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
@@ -72,7 +70,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
 
     changelog:
         section: features
-        inherit: all
         project: mkchlog
 
 commit ac0df22c6b5c9e4ec387b61b7997d420a1b6d36c
@@ -86,7 +83,6 @@ Date:   Tue Oct 31 13:46:59 2023 +0100
     changelog:
         project: main
         section: features
-        inherit: all
 
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -99,7 +95,6 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: perf
-        inherit: all
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -184,7 +179,6 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: doc
-        inherit: title
         title-is-enough: true
 
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
@@ -196,7 +190,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
     changelog:
         project: mkchlog
         section: dev
-        inherit: title
         title-is-enough: true
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
@@ -211,7 +204,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
 
     changelog:
         section: features
-        inherit: all
         project: mkchlog
 
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
@@ -225,7 +217,6 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: perf
-        inherit: all
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -304,13 +295,10 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
      - project:
         name: mkchlog
         section: dev
-        inherit: all
         title-is-enough: true
      - project:
         name: mkchlog-action
-        section: features
-        inherit: all
-",
+        section: features",
     );
 
     let project = Some("mkchlog".to_owned());
@@ -362,7 +350,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
      - project:
         name: mkchlog
         section: dev
-        inherit: title
         title-is-enough: true
      - project:
         name: mkchlog-action
@@ -427,7 +414,6 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
     changelog:
         project: wrong-name
         section: doc
-        inherit: title
         title-is-enough: true",
     );
 
@@ -456,7 +442,6 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: doc
-        inherit: title
         title-is-enough: true
 
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
@@ -468,7 +453,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
     changelog:
         project: mkchlog
         section: dev
-        inherit: title
         title-is-enough: true
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
@@ -483,7 +467,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
 
     changelog:
         section: features
-        inherit: all
         project: mkchlog
 
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
@@ -497,7 +480,6 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: perf
-        inherit: all
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -580,7 +562,6 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: doc
-        inherit: title
         title-is-enough: true
 
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
@@ -592,7 +573,6 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
     changelog:
         project: mkchlog
         section: dev
-        inherit: title
         title-is-enough: true
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
@@ -607,7 +587,6 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
 
     changelog:
         section: features
-        inherit: all
         project: mkchlog
 
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
@@ -621,7 +600,6 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: perf
-        inherit: all
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -700,7 +678,6 @@ Date:   Tue Jun 13 16:24:22 2023 +0200
     fixes or other things irrelevant to the user of a project.
 
     changelog:
-        inherit: all
         section: feature",
     );
 

--- a/tests/integration_test_projects.rs
+++ b/tests/integration_test_projects.rs
@@ -2,6 +2,7 @@ mod mocks;
 
 use mkchlog::changelog;
 use mkchlog::changelog::Changelog;
+use mkchlog::config::Command;
 use mkchlog::git::Git;
 use mkchlog::template::Template;
 use mocks::GitCmdMock;
@@ -9,6 +10,7 @@ use std::fs::File;
 
 const YAML_FILE_PROJECTS: &str = "tests/mkchlog_projects.yml";
 const YAML_FILE_SINCE_COMMIT: &str = "tests/mkchlog_projects_since_commit.yml";
+const COMMAND: Command = Command::Generate;
 
 #[test]
 fn it_produces_correct_output_for_project1() {
@@ -29,6 +31,8 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
+mkchlog-action/README.md
+
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -40,6 +44,8 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
+
+mkchlog/.github/workflows/ci.yml
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -56,6 +62,28 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
+mkchlog/.mkchlog.yml
+mkchlog/README.md
+mkchlog/src/lib.rs
+mkchlog/src/template.rs
+mkchlog/tests/mkchlog.yml
+
+commit ac0df22c6b5c9e4ec387b61b7997d420a1b6d36c
+Author: Vojtěch Toman <cry.wolf@centrum.cz>
+Date:   Tue Oct 31 13:46:59 2023 +0100
+
+    Allow parsing commit(s) from stdin
+
+    It is possible to check the commit before it is actually commited. Useful to use in a commit-msg git hook.
+
+    changelog:
+        project:main
+        section: features
+        inherit: all
+
+.githooks/commit-msg
+README.md
+
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -68,6 +96,9 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
+
+mkchlog-action/node_modules/libmkchlog/libmkchlog.js
+mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -88,6 +119,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
+mkchlog/.github/workflows/test.yml
+mkchlog/Cargo.lock
+mkchlog/Cargo.toml
+mkchlog/README.md
+mkchlog/clippy.toml
+mkchlog/src/template.rs
+
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -107,7 +145,12 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
             project: mkchlog
             section: dev
             title-is-enough: true
-",
+
+mkchlog/.github/workflows/changelog.yml
+mkchlog/.github/workflows/test.yml
+mkchlog/.mkchlog.yml
+mkchlog/tests/integration_test.rs
+mkchlog/tests/mkchlog.yml",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -118,7 +161,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     let mut changelog = Changelog::new(&mut template, git);
 
     let project = Some("mkchlog".to_owned());
-    let output = changelog.generate(project).unwrap();
+    let output = changelog.generate(project, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -163,6 +206,8 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
+mkchlog-action/README.md
+
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -174,6 +219,8 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
+
+mkchlog/.github/workflows/ci.yml
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -190,6 +237,12 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
+mkchlog/.mkchlog.yml
+mkchlog/README.md
+mkchlog/src/lib.rs
+mkchlog/src/template.rs
+mkchlog/tests/mkchlog.yml
+
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -202,6 +255,9 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
+
+mkchlog-action/node_modules/libmkchlog/libmkchlog.js
+mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -222,6 +278,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
+mkchlog/.github/workflows/test.yml
+mkchlog/Cargo.lock
+mkchlog/mkchlog/Cargo.toml
+mkchlog/README.md
+mkchlog/clippy.toml
+mkchlog/src/template.rs
+
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -241,7 +304,12 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
             project: mkchlog
             section: dev
             title-is-enough: true
-",
+
+mkchlog/.github/workflows/changelog.yml
+mkchlog/.github/workflows/test.yml
+mkchlog/.mkchlog.yml
+mkchlog/tests/integration_test.rs
+mkchlog/tests/mkchlog.yml",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -252,7 +320,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     let mut changelog = Changelog::new(&mut template, git);
 
     let project = Some("mkchlog-action".to_owned());
-    let output = changelog.generate(project).unwrap();
+    let output = changelog.generate(project, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -273,7 +341,7 @@ This updates the wasm module to one which was compiled with `--release`.
 }
 
 #[test]
-fn fails_when_called_with_incorrect_project_argument_provided() {
+fn fails_when_called_with_incorrect_project_argument_provided_when_calling_the_app() {
     let mocked_log = String::from("");
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -284,13 +352,91 @@ fn fails_when_called_with_incorrect_project_argument_provided() {
     let mut changelog = Changelog::new(&mut template, git);
 
     let project = Some("nonsense".to_owned());
-    let res = changelog.generate(project);
+    let res = changelog.generate(project, COMMAND);
 
     assert!(res.is_err());
     assert!(res
         .unwrap_err()
         .to_string()
         .starts_with("Project 'nonsense' not configured in config file"));
+}
+
+#[test]
+fn fails_when_commit_contains_invalid_project_name() {
+    let mocked_log = String::from(
+        "\
+commit df841802133a1ad7556245bdce59417270de5c3f
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 25 10:12:50 2023 +0200
+
+    Add configuration instructions to README.md
+
+    The `fetch-depth` configuration isn't obvious for newbies so this
+    documents it.
+
+    changelog:
+        project: wrong-name
+        section: doc
+        inherit: title
+        title-is-enough: true
+
+README.md
+    ",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_PROJECTS).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog".to_owned());
+    let res = changelog.generate(project, COMMAND);
+
+    assert!(res.is_err());
+    assert!(res.unwrap_err().to_string().starts_with(
+        "Incorrect (not allowed in config file) project name 'wrong-name' in changelog message"
+    ));
+}
+
+#[test]
+fn fails_when_commit_changes_files_that_are_not_in_project_directory() {
+    let mocked_log = String::from(
+        "\
+commit ac0df22c6b5c9e4ec387b61b7997d420a1b6d36c
+Author: Vojtěch Toman <cry.wolf@centrum.cz>
+Date:   Tue Oct 31 13:46:59 2023 +0100
+
+    Allow parsing commit(s) from stdin
+
+    It is possible to check the commit before it is actually commited. Useful to use in a commit-msg git hook.
+
+    changelog:
+        project: main
+        section: features
+        inherit: all
+
+.githooks/commit-msg
+README.md
+src/config.rs",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_PROJECTS).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog".to_owned());
+    let res = changelog.generate(project, COMMAND);
+
+    assert!(res.is_err());
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .starts_with("File: 'src/config.rs' does not belong to project 'main' in commit:"));
 }
 
 #[test]
@@ -312,6 +458,8 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
+mkchlog-action/README.md
+
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -323,6 +471,8 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
+
+mkchlog/.github/workflows/ci.yml
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -339,6 +489,12 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
+mkchlog/.mkchlog.yml
+mkchlog/README.md
+mkchlog/src/lib.rs
+mkchlog/src/template.rs
+mkchlog/tests/mkchlog.yml
+
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -351,6 +507,9 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
+
+mkchlog-action/node_modules/libmkchlog/libmkchlog.js
+mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -370,6 +529,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
+.github/workflows/test.yml
+Cargo.lock
+Cargo.toml
+README.md
+clippy.toml
+src/template.rs
+
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -388,7 +554,12 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             section: dev
             title-is-enough: true
-",
+
+.github/workflows/changelog.yml
+.github/workflows/test.yml
+.mkchlog.yml
+tests/integration_test.rs
+tests/mkchlog.yml",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -399,7 +570,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     let mut changelog = Changelog::new(&mut template, git);
 
     let project = Some("mkchlog".to_owned());
-    let output = changelog.generate(project).unwrap();
+    let output = changelog.generate(project, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -444,6 +615,8 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
         inherit: title
         title-is-enough: true
 
+mkchlog-action/README.md
+
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
 Date:   Tue Oct 24 19:17:09 2023 +0200
@@ -455,6 +628,9 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
         section: dev
         inherit: title
         title-is-enough: true
+
+mkchlog/.github/workflows/ci.yml
+mkchlog/README.md
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -471,6 +647,12 @@ Date:   Sun Oct 22 23:08:57 2023 +0200
         inherit: all
         project: mkchlog
 
+mkchlog/.mkchlog.yml
+mkchlog/README.md
+mkchlog/src/lib.rs
+mkchlog/src/template.rs
+mkchlog/tests/mkchlog.yml
+
 commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sun Oct 22 10:12:50 2023 +0200
@@ -483,6 +665,9 @@ Date:   Sun Oct 22 10:12:50 2023 +0200
         project: mkchlog-action
         section: perf
         inherit: all
+
+mkchlog-action/node_modules/libmkchlog/libmkchlog.js
+mkchlog-action/node_modules/libmkchlog/libmkchlog_bg.wasm
 
 commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -502,6 +687,13 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
         section: features
         title-is-enough: true
 
+.github/workflows/test.yml
+Cargo.lock
+Cargo.toml
+README.md
+clippy.toml
+src/template.rs
+
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
 Date:   Sat Oct 21 19:00:27 2023 +0200
@@ -520,7 +712,12 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             section: dev
             title-is-enough: true
-",
+
+.github/workflows/changelog.yml
+.github/workflows/test.yml
+.mkchlog.yml
+tests/integration_test.rs
+tests/mkchlog.yml",
     );
 
     let git_cmd = Box::new(GitCmdMock::new(mocked_log));
@@ -531,7 +728,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     let mut changelog = Changelog::new(&mut template, git);
 
     let project = Some("mkchlog-action".to_owned());
-    let output = changelog.generate(project).unwrap();
+    let output = changelog.generate(project, COMMAND).unwrap();
 
     let exp_output = "\
 ============================================
@@ -549,4 +746,44 @@ This updates the wasm module to one which was compiled with `--release`.
 ============================================";
 
     assert_eq!(exp_output, output);
+}
+
+#[test]
+fn when_called_with_check_command_fails_if_commits_are_invalid() {
+    // test that we can call it without providing project name when just checking commits, not generating changelog
+    // and it will correctly find commit with invalid or missing project
+
+    let mocked_log = String::from(
+        "\
+commit 62db026b0ead7f0659df10c70e402c70ede5d7dd
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Jun 13 16:24:22 2023 +0200
+
+    Added ability to skip commits.
+
+    This allows commits to be skipped by typing 'changelog: skip'
+    at the end of the commit. This is mainly useful for typo
+    fixes or other things irrelevant to the user of a project.
+
+    changelog:
+        inherit: all
+        section: feature
+
+src/changelog.rs",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_SINCE_COMMIT).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let res = changelog.generate(None, Command::Check);
+
+    assert!(res.is_err());
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .starts_with("Missing 'project' key in changelog message:"));
 }

--- a/tests/integration_test_projects.rs
+++ b/tests/integration_test_projects.rs
@@ -1,0 +1,552 @@
+mod mocks;
+
+use mkchlog::changelog;
+use mkchlog::changelog::Changelog;
+use mkchlog::git::Git;
+use mkchlog::template::Template;
+use mocks::GitCmdMock;
+use std::fs::File;
+
+const YAML_FILE_PROJECTS: &str = "tests/mkchlog_projects.yml";
+const YAML_FILE_SINCE_COMMIT: &str = "tests/mkchlog_projects_since_commit.yml";
+
+#[test]
+fn it_produces_correct_output_for_project1() {
+    let mocked_log = String::from(
+        "\
+commit df841802133a1ad7556245bdce59417270de5c3f
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 25 10:12:50 2023 +0200
+
+    Add configuration instructions to README.md
+
+    The `fetch-depth` configuration isn't obvious for newbies so this
+    documents it.
+
+    changelog:
+        project: mkchlog-action
+        section: doc
+        inherit: title
+        title-is-enough: true
+
+commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Oct 24 19:17:09 2023 +0200
+
+    Setup CI
+
+    changelog:
+        project: mkchlog
+        section: dev
+        inherit: title
+        title-is-enough: true
+
+commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Sun Oct 22 23:08:57 2023 +0200
+
+    Allow configuring commit ID in yaml
+
+    This adds a field `skip-commits-up-to` into top level of yaml config so
+    that users don't have to remember what to supply in `-c` argument every
+    time.
+
+    changelog:
+        section: features
+        inherit: all
+        project: mkchlog
+
+commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 10:12:50 2023 +0200
+
+    Publish release version rather than debug
+
+    This updates the wasm module to one which was compiled with `--release`.
+
+    changelog:
+        project: mkchlog-action
+        section: perf
+        inherit: all
+
+commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 09:12:50 2023 +0200
+
+    Support building on Debian Bookworm
+
+    This change lowers the requirements for dependencies so that the code
+    compiles on Rust 1.63 which is in Debian Bookworm. Further, the
+    dependencies are lowered such that the packages vendored in Debian
+    Bookworm can be used directly.
+
+    This uses version ranges so that the newest crates can still be used
+    (they didn't break our code).
+
+    changelog:
+        project: mkchlog
+        section: features
+        title-is-enough: true
+
+commit 624c947820cba6c0665b84bfc139f209277f2a95
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sat Oct 21 19:00:27 2023 +0200
+
+    Setup Github Actions
+
+    This configures github actions to test `mkchlog` as well as run it on
+    its own repository. Also moved `.mkchlog.yml`, which was used in test,
+    to `tests/mkchlog.yml` and created custom `.mkchlog.yml` that's used in
+    this project.
+
+    The new `.mkchlog.yml` is heavily inspired by the original example with
+    more sections, so we're more flexible in the future. Includes a section
+    used in this commit. :)
+
+    changelog:
+            project: mkchlog
+            section: dev
+            title-is-enough: true
+",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_PROJECTS).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog".to_owned());
+    let output = changelog.generate(project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## New features
+
+* Support building on Debian Bookworm
+
+### Allow configuring commit ID in yaml
+
+This adds a field `skip-commits-up-to` into top level of yaml config so that users don't have to remember what to supply in `-c` argument every time.
+
+## Development
+
+Internal development changes
+
+* Setup CI
+
+* Setup Github Actions
+
+============================================";
+
+    assert_eq!(exp_output, output);
+}
+
+#[test]
+fn it_produces_correct_output_for_project2() {
+    let mocked_log = String::from(
+        "\
+commit df841802133a1ad7556245bdce59417270de5c3f
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 25 10:12:50 2023 +0200
+
+    Add configuration instructions to README.md
+
+    The `fetch-depth` configuration isn't obvious for newbies so this
+    documents it.
+
+    changelog:
+        project: mkchlog-action
+        section: doc
+        inherit: title
+        title-is-enough: true
+
+commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Oct 24 19:17:09 2023 +0200
+
+    Setup CI
+
+    changelog:
+        project: mkchlog
+        section: dev
+        inherit: title
+        title-is-enough: true
+
+commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Sun Oct 22 23:08:57 2023 +0200
+
+    Allow configuring commit ID in yaml
+
+    This adds a field `skip-commits-up-to` into top level of yaml config so
+    that users don't have to remember what to supply in `-c` argument every
+    time.
+
+    changelog:
+        section: features
+        inherit: all
+        project: mkchlog
+
+commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 10:12:50 2023 +0200
+
+    Publish release version rather than debug
+
+    This updates the wasm module to one which was compiled with `--release`.
+
+    changelog:
+        project: mkchlog-action
+        section: perf
+        inherit: all
+
+commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 09:12:50 2023 +0200
+
+    Support building on Debian Bookworm
+
+    This change lowers the requirements for dependencies so that the code
+    compiles on Rust 1.63 which is in Debian Bookworm. Further, the
+    dependencies are lowered such that the packages vendored in Debian
+    Bookworm can be used directly.
+
+    This uses version ranges so that the newest crates can still be used
+    (they didn't break our code).
+
+    changelog:
+        project: mkchlog
+        section: features
+        title-is-enough: true
+
+commit 624c947820cba6c0665b84bfc139f209277f2a95
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sat Oct 21 19:00:27 2023 +0200
+
+    Setup Github Actions
+
+    This configures github actions to test `mkchlog` as well as run it on
+    its own repository. Also moved `.mkchlog.yml`, which was used in test,
+    to `tests/mkchlog.yml` and created custom `.mkchlog.yml` that's used in
+    this project.
+
+    The new `.mkchlog.yml` is heavily inspired by the original example with
+    more sections, so we're more flexible in the future. Includes a section
+    used in this commit. :)
+
+    changelog:
+            project: mkchlog
+            section: dev
+            title-is-enough: true
+",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_PROJECTS).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog-action".to_owned());
+    let output = changelog.generate(project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## Performance improvements
+
+### Publish release version rather than debug
+
+This updates the wasm module to one which was compiled with `--release`.
+
+## Documentation changes
+
+* Add configuration instructions to README.md
+
+============================================";
+
+    assert_eq!(exp_output, output);
+}
+
+#[test]
+fn fails_when_called_with_incorrect_project_argument_provided() {
+    let mocked_log = String::from("");
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_PROJECTS).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("nonsense".to_owned());
+    let res = changelog.generate(project);
+
+    assert!(res.is_err());
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .starts_with("Project 'nonsense' not configured in config file"));
+}
+
+#[test]
+fn it_produces_correct_output_for_project1_since_commit() {
+    let mocked_log = String::from(
+        "\
+commit df841802133a1ad7556245bdce59417270de5c3f
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 25 10:12:50 2023 +0200
+
+    Add configuration instructions to README.md
+
+    The `fetch-depth` configuration isn't obvious for newbies so this
+    documents it.
+
+    changelog:
+        project: mkchlog-action
+        section: doc
+        inherit: title
+        title-is-enough: true
+
+commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Oct 24 19:17:09 2023 +0200
+
+    Setup CI
+
+    changelog:
+        project: mkchlog
+        section: dev
+        inherit: title
+        title-is-enough: true
+
+commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Sun Oct 22 23:08:57 2023 +0200
+
+    Allow configuring commit ID in yaml
+
+    This adds a field `skip-commits-up-to` into top level of yaml config so
+    that users don't have to remember what to supply in `-c` argument every
+    time.
+
+    changelog:
+        section: features
+        inherit: all
+        project: mkchlog
+
+commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 10:12:50 2023 +0200
+
+    Publish release version rather than debug
+
+    This updates the wasm module to one which was compiled with `--release`.
+
+    changelog:
+        project: mkchlog-action
+        section: perf
+        inherit: all
+
+commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 09:12:50 2023 +0200
+
+    Support building on Debian Bookworm
+
+    This change lowers the requirements for dependencies so that the code
+    compiles on Rust 1.63 which is in Debian Bookworm. Further, the
+    dependencies are lowered such that the packages vendored in Debian
+    Bookworm can be used directly.
+
+    This uses version ranges so that the newest crates can still be used
+    (they didn't break our code).
+
+    changelog:
+        section: features
+        title-is-enough: true
+
+commit 624c947820cba6c0665b84bfc139f209277f2a95
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sat Oct 21 19:00:27 2023 +0200
+
+    Setup Github Actions
+
+    This configures github actions to test `mkchlog` as well as run it on
+    its own repository. Also moved `.mkchlog.yml`, which was used in test,
+    to `tests/mkchlog.yml` and created custom `.mkchlog.yml` that's used in
+    this project.
+
+    The new `.mkchlog.yml` is heavily inspired by the original example with
+    more sections, so we're more flexible in the future. Includes a section
+    used in this commit. :)
+
+    changelog:
+            section: dev
+            title-is-enough: true
+",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_SINCE_COMMIT).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog".to_owned());
+    let output = changelog.generate(project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## New features
+
+* Support building on Debian Bookworm
+
+### Allow configuring commit ID in yaml
+
+This adds a field `skip-commits-up-to` into top level of yaml config so that users don't have to remember what to supply in `-c` argument every time.
+
+## Development
+
+Internal development changes
+
+* Setup CI
+
+* Setup Github Actions
+
+============================================";
+
+    assert_eq!(exp_output, output);
+}
+
+#[test]
+fn it_produces_correct_output_for_project2_since_commit() {
+    let mocked_log = String::from(
+        "\
+commit df841802133a1ad7556245bdce59417270de5c3f
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 25 10:12:50 2023 +0200
+
+    Add configuration instructions to README.md
+
+    The `fetch-depth` configuration isn't obvious for newbies so this
+    documents it.
+
+    changelog:
+        project: mkchlog-action
+        section: doc
+        inherit: title
+        title-is-enough: true
+
+commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Tue Oct 24 19:17:09 2023 +0200
+
+    Setup CI
+
+    changelog:
+        project: mkchlog
+        section: dev
+        inherit: title
+        title-is-enough: true
+
+commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
+Author: Cry Wolf <cry.wolf@centrum.cz>
+Date:   Sun Oct 22 23:08:57 2023 +0200
+
+    Allow configuring commit ID in yaml
+
+    This adds a field `skip-commits-up-to` into top level of yaml config so
+    that users don't have to remember what to supply in `-c` argument every
+    time.
+
+    changelog:
+        section: features
+        inherit: all
+        project: mkchlog
+
+commit 11964cbb5ac05c5a19d75b5bebcc74ebc867e438
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 10:12:50 2023 +0200
+
+    Publish release version rather than debug
+
+    This updates the wasm module to one which was compiled with `--release`.
+
+    changelog:
+        project: mkchlog-action
+        section: perf
+        inherit: all
+
+commit 22e27ce785698c4a873eb5e2ad9e0cf9c849be8d
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sun Oct 22 09:12:50 2023 +0200
+
+    Support building on Debian Bookworm
+
+    This change lowers the requirements for dependencies so that the code
+    compiles on Rust 1.63 which is in Debian Bookworm. Further, the
+    dependencies are lowered such that the packages vendored in Debian
+    Bookworm can be used directly.
+
+    This uses version ranges so that the newest crates can still be used
+    (they didn't break our code).
+
+    changelog:
+        section: features
+        title-is-enough: true
+
+commit 624c947820cba6c0665b84bfc139f209277f2a95
+Author: Martin Habovstiak <martin.habovstiak@gmail.com>
+Date:   Sat Oct 21 19:00:27 2023 +0200
+
+    Setup Github Actions
+
+    This configures github actions to test `mkchlog` as well as run it on
+    its own repository. Also moved `.mkchlog.yml`, which was used in test,
+    to `tests/mkchlog.yml` and created custom `.mkchlog.yml` that's used in
+    this project.
+
+    The new `.mkchlog.yml` is heavily inspired by the original example with
+    more sections, so we're more flexible in the future. Includes a section
+    used in this commit. :)
+
+    changelog:
+            section: dev
+            title-is-enough: true
+",
+    );
+
+    let git_cmd = Box::new(GitCmdMock::new(mocked_log));
+    let git = Git::new(git_cmd);
+
+    let f = File::open(YAML_FILE_SINCE_COMMIT).unwrap();
+    let mut template = Template::<changelog::Changes>::new(f).unwrap();
+    let mut changelog = Changelog::new(&mut template, git);
+
+    let project = Some("mkchlog-action".to_owned());
+    let output = changelog.generate(project).unwrap();
+
+    let exp_output = "\
+============================================
+
+## Performance improvements
+
+### Publish release version rather than debug
+
+This updates the wasm module to one which was compiled with `--release`.
+
+## Documentation changes
+
+* Add configuration instructions to README.md
+
+============================================";
+
+    assert_eq!(exp_output, output);
+}

--- a/tests/integration_test_projects.rs
+++ b/tests/integration_test_projects.rs
@@ -45,7 +45,7 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: doc
-        title-is-enough: true
+        only-title: true
 
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -56,7 +56,7 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
     changelog:
         project: mkchlog
         section: dev
-        title-is-enough: true
+        only-title: true
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -113,7 +113,7 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
     changelog:
         project: mkchlog
         section: features
-        title-is-enough: true
+        only-title: true
 
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -133,7 +133,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             project: mkchlog
             section: dev
-            title-is-enough: true",
+            only-title: true",
     );
 
     let project = Some("mkchlog".to_owned());
@@ -179,7 +179,7 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: doc
-        title-is-enough: true
+        only-title: true
 
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -190,7 +190,7 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
     changelog:
         project: mkchlog
         section: dev
-        title-is-enough: true
+        only-title: true
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -235,7 +235,7 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
     changelog:
         project: mkchlog
         section: features
-        title-is-enough: true
+        only-title: true
 
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -255,7 +255,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
     changelog:
             project: mkchlog
             section: dev
-            title-is-enough: true",
+            only-title: true",
     );
 
     let project = Some("mkchlog-action".to_owned());
@@ -295,7 +295,7 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
      - project:
         name: mkchlog
         section: dev
-        title-is-enough: true
+        only-title: true
      - project:
         name: mkchlog-action
         section: features",
@@ -350,7 +350,7 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
      - project:
         name: mkchlog
         section: dev
-        title-is-enough: true
+        only-title: true
      - project:
         name: mkchlog-action
         skip: true
@@ -414,7 +414,7 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
     changelog:
         project: wrong-name
         section: doc
-        title-is-enough: true",
+        only-title: true",
     );
 
     let project = Some("mkchlog".to_owned());
@@ -442,7 +442,7 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: doc
-        title-is-enough: true
+        only-title: true
 
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -453,7 +453,7 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
     changelog:
         project: mkchlog
         section: dev
-        title-is-enough: true
+        only-title: true
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -497,7 +497,7 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
 
     changelog:
         section: features
-        title-is-enough: true
+        only-title: true
 
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -516,7 +516,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
 
     changelog:
             section: dev
-            title-is-enough: true",
+            only-title: true",
     );
 
     let project = Some("mkchlog".to_owned());
@@ -562,7 +562,7 @@ Date:   Sun Oct 25 10:12:50 2023 +0200
     changelog:
         project: mkchlog-action
         section: doc
-        title-is-enough: true
+        only-title: true
 
 commit b532ebcb0a214fbc69a5f5138e43eec14ea1a9dc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -573,7 +573,7 @@ Date:   Tue Oct 24 19:17:09 2023 +0200
     changelog:
         project: mkchlog
         section: dev
-        title-is-enough: true
+        only-title: true
 
 commit cdbfeb9b2576e07f12da569c54f5ec3cd7b9c0fc
 Author: Cry Wolf <cry.wolf@centrum.cz>
@@ -617,7 +617,7 @@ Date:   Sun Oct 22 09:12:50 2023 +0200
 
     changelog:
         section: features
-        title-is-enough: true
+        only-title: true
 
 commit 624c947820cba6c0665b84bfc139f209277f2a95
 Author: Martin Habovstiak <martin.habovstiak@gmail.com>
@@ -636,7 +636,7 @@ Date:   Sat Oct 21 19:00:27 2023 +0200
 
     changelog:
             section: dev
-            title-is-enough: true",
+            only-title: true",
     );
 
     let project = Some("mkchlog-action".to_owned());

--- a/tests/mkchlog.yml
+++ b/tests/mkchlog.yml
@@ -1,5 +1,9 @@
 skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
 
+skip-commits-list:
+    - 12b6a464d165c18cc29394e332d6f6c6d09170e2
+    - a27c77b683c6334e79e94c232ed699f5a5216fee
+
 sections:
     # section identifier selected by project maintainer
     security:

--- a/tests/mkchlog_projects.yml
+++ b/tests/mkchlog_projects.yml
@@ -1,0 +1,28 @@
+skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
+
+projects:
+    names: [mkchlog, mkchlog-action] # list of project names
+
+sections:
+    # section identifier selected by project maintainer
+    security:
+        # The header presented to the user
+        title: Security
+        # desctiption is optional and will appear above changes
+        description: This section contains very important security-related changes.
+        subsections:
+            vuln_fixes:
+                title: Fixed vulnerabilities
+    features:
+        title: New features
+    bug_fixes:
+        title: Fixed bugs
+    breaking:
+        title: Breaking changes
+    perf:
+        title: Performance improvements
+    doc:
+        title: Documentation changes
+    dev:
+        title: Development
+        description: Internal development changes

--- a/tests/mkchlog_projects.yml
+++ b/tests/mkchlog_projects.yml
@@ -1,10 +1,16 @@
 skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
 
 projects:
-    list:  # list of allowed projects
-    - main: [".", .github, .githooks] # name: [directory1, directory2]
-    - mkchlog: [mkchlog] # name: [directory]
-    - mkchlog-action: [mkchlog-action] # name: [directory]
+  list:
+    - project:
+        name: main
+        dirs: [".", .github, .githooks]
+    - project:
+        name: mkchlog
+        dirs: [mkchlog]
+    - project:
+        name: mkchlog-action
+        dirs: [mkchlog-action]
 
 sections:
     # section identifier selected by project maintainer

--- a/tests/mkchlog_projects.yml
+++ b/tests/mkchlog_projects.yml
@@ -1,7 +1,10 @@
 skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
 
 projects:
-    names: [mkchlog, mkchlog-action] # list of project names
+    list:  # list of allowed projects
+    - main: [".", .github, .githooks] # name: [directory1, directory2]
+    - mkchlog: [mkchlog] # name: [directory]
+    - mkchlog-action: [mkchlog-action] # name: [directory]
 
 sections:
     # section identifier selected by project maintainer

--- a/tests/mkchlog_projects_since_commit.yml
+++ b/tests/mkchlog_projects_since_commit.yml
@@ -1,13 +1,19 @@
 skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
 
 projects:
-    list:  # list of allowed projects
-    - main: [".", .github, .githooks] # name: [directory1, directory2]
-    - mkchlog: [mkchlog] # name: [directory]
-    - mkchlog-action: [mkchlog-action] # name: [directory]
+  list:
+    - project:
+        name: main
+        dirs: [".", .github, .githooks]
+    - project:
+        name: mkchlog
+        dirs: [mkchlog]
+    - project:
+        name: mkchlog-action
+        dirs: [mkchlog-action]
 
-    since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER
-    default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME
+  since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER
+  default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME
 
 sections:
     # section identifier selected by project maintainer

--- a/tests/mkchlog_projects_since_commit.yml
+++ b/tests/mkchlog_projects_since_commit.yml
@@ -1,7 +1,11 @@
 skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
 
 projects:
-    names: [mkchlog, mkchlog-action] # list of project names
+    list:  # list of allowed projects
+    - main: [".", .github, .githooks] # name: [directory1, directory2]
+    - mkchlog: [mkchlog] # name: [directory]
+    - mkchlog-action: [mkchlog-action] # name: [directory]
+
     since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER
     default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME
 

--- a/tests/mkchlog_projects_since_commit.yml
+++ b/tests/mkchlog_projects_since_commit.yml
@@ -1,0 +1,30 @@
+skip-commits-up-to: bc58e6bf2cf640d46aa832e297d0f215f76dfce0
+
+projects:
+    names: [mkchlog, mkchlog-action] # list of project names
+    since-commit: 11964cbb5ac05c5a19d75b5bebcc74ebc867e438 # projects are mandatory since COMMIT_NUMBER
+    default: mkchlog # commits up to COMMIT_NUMBER are considered belonging to the project NAME
+
+sections:
+    # section identifier selected by project maintainer
+    security:
+        # The header presented to the user
+        title: Security
+        # desctiption is optional and will appear above changes
+        description: This section contains very important security-related changes.
+        subsections:
+            vuln_fixes:
+                title: Fixed vulnerabilities
+    features:
+        title: New features
+    bug_fixes:
+        title: Fixed bugs
+    breaking:
+        title: Breaking changes
+    perf:
+        title: Performance improvements
+    doc:
+        title: Documentation changes
+    dev:
+        title: Development
+        description: Internal development changes

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -32,7 +32,7 @@ fn run(config: &str, git_callback: js_sys::Function) -> Result<(), Box<dyn std::
 
     let mut changelog = Changelog::new(&mut template, git);
 
-    changelog.generate()?;
+    changelog.generate(None)?;
     Ok(())
 }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -19,6 +19,7 @@ pub fn check(config: &str, git_callback: js_sys::Function) -> Result<(), JsValue
 fn run(config: &str, git_callback: js_sys::Function) -> Result<(), Box<dyn std::error::Error>> {
     use mkchlog::changelog::Changelog;
     use mkchlog::changelog::Changes;
+    use mkchlog::config::Command;
     use mkchlog::template::Template;
 
     let mut template = Template::<Changes>::from_str(config)?;
@@ -32,7 +33,7 @@ fn run(config: &str, git_callback: js_sys::Function) -> Result<(), Box<dyn std::
 
     let mut changelog = Changelog::new(&mut template, git);
 
-    changelog.generate(None)?;
+    changelog.generate(None, Command::Check)?;
     Ok(())
 }
 


### PR DESCRIPTION
Some repositories host multiple projects that are related but have disjoint changelogs. This is typical for multi-crate workspaces in Rust. When configured as multi-project repo and using project: keyword in commit changelogs this feature allows to generate separate changelogs.

closes #14 , closes #16 